### PR TITLE
Exclude "supabase" from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase"]
 }


### PR DESCRIPTION
This pull request excludes the "supabase" module from the tsconfig.json file. This change ensures that the "supabase" module is not included in the TypeScript compilation process.