### PR TITLE
Harden crawling and make thread moves atomic

### DIFF
--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const updateSessionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/utils/supabase/middleware", () => ({
+	updateSession: updateSessionMock,
+}));
+
+import { proxy } from "./proxy";
+
+describe("proxy", () => {
+	beforeEach(() => {
+		updateSessionMock.mockResolvedValue(NextResponse.next());
+	});
+
+	it("내부 크롤링 API는 세션 proxy를 우회해 원본 요청 헤더를 보존한다", async () => {
+		const request = new NextRequest("http://localhost/api/crawl", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"x-applemint-internal-secret": "test-internal-secret",
+			},
+			body: JSON.stringify({ target: "arcalive" }),
+		});
+
+		const response = await proxy(request);
+
+		expect(updateSessionMock).not.toHaveBeenCalled();
+		expect(response.headers.get("x-middleware-override-headers")).toBeNull();
+	});
+
+	it("수동 크롤링 API는 로그인 세션 갱신을 유지한다", async () => {
+		const request = new NextRequest("http://localhost/api/crawl/manual", {
+			method: "POST",
+		});
+
+		await proxy(request);
+
+		expect(updateSessionMock).toHaveBeenCalledWith(request);
+	});
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,12 @@
-import type { NextRequest } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { updateSession } from "@/utils/supabase/middleware";
 
 export async function proxy(request: NextRequest) {
+	// 내부 크롤링 API는 쿠키 세션을 사용하지 않으며 원본 인증 헤더와 JSON body를 보존해야 한다.
+	if (request.nextUrl.pathname === "/api/crawl") {
+		return NextResponse.next();
+	}
+
 	return await updateSession(request);
 }
 

--- a/utils/supabase/middleware.test.ts
+++ b/utils/supabase/middleware.test.ts
@@ -1,0 +1,25 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+import { getAllowedRequestHeaders } from "./middleware";
+
+describe("getAllowedRequestHeaders", () => {
+	it("JSON POST body 처리에 필요한 헤더를 세션 갱신 이후에도 보존한다", () => {
+		const request = new NextRequest("http://localhost/api/crawl/manual", {
+			method: "POST",
+			headers: {
+				"Content-Length": "22",
+				"Content-Type": "application/json",
+				Cookie: "session=test",
+				"x-untrusted-header": "discard-me",
+			},
+			body: JSON.stringify({ target: "arcalive" }),
+		});
+
+		const headers = getAllowedRequestHeaders(request);
+
+		expect(headers.get("content-length")).toBe("22");
+		expect(headers.get("content-type")).toBe("application/json");
+		expect(headers.get("cookie")).toBe("session=test");
+		expect(headers.get("x-untrusted-header")).toBeNull();
+	});
+});

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -3,6 +3,8 @@ import { type NextRequest, NextResponse } from "next/server";
 
 const FORWARDED_HEADER_ALLOWLIST = [
 	"accept-language",
+	"content-length",
+	"content-type",
 	"cookie",
 	"host",
 	"user-agent",
@@ -13,7 +15,7 @@ const FORWARDED_HEADER_ALLOWLIST = [
 	"x-real-ip",
 ] as const;
 
-const getAllowedRequestHeaders = (request: NextRequest) => {
+export const getAllowedRequestHeaders = (request: NextRequest) => {
 	const headers = new Headers();
 
 	for (const headerName of FORWARDED_HEADER_ALLOWLIST) {


### PR DESCRIPTION
## Summary

- Add atomic crawl ingestion and thread move operations with Supabase migrations and concurrency coverage
- Harden crawl source fetching with timeouts, internal authentication, and updated route handling
- Improve trash and quick-save flows with shared mutation/query-cache utilities
- Update deployment documentation and project configuration

## Testing

- Added and updated Vitest coverage for crawl routes, authentication, mutations, caching, middleware, and client behavior
- Added Supabase SQL tests for atomic operations and concurrent ingestion
- Not run (not requested)