### PR TITLE
P1-4 파서 회귀 방지 및 보안 의존성 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,12 @@ erDiagram
 ## 유지보수 가이드
 
 ### 1) 크롤러 소스 추가/변경
-- `app/api/crawl/<source>.ts`에 소스별 수집 로직 구현
+- `app/api/crawl/<source>-parser.ts`에 네트워크와 분리된 순수 파서 구현
+- `app/api/crawl/<source>.ts`에서 요청 결과를 공통 파서 계약에 연결
 - `app/api/crawl/route.ts` 스위치에 타겟 등록
-- 반환 타입은 `{items, attempted, succeeded, failures}` 구조를 유지
+- 반환 타입은 `{items, attempted, succeeded, failures, warnings}` 구조를 유지
+- 정상 빈 목록은 `empty-list`, 최소 추출 건수 미달은 `below-minimum-items` warning으로 기록하며 구조 변경은 parser failure로 구분
+- 파서 변경 시 `app/api/crawl/fixtures`의 정제 fixture와 source별 parser 테스트를 함께 갱신
 - 소스 장애 대비 재시도/로그 전략 유지 (`retryOperation`, `logger.ts`)
 
 ### 2) 데이터 분류/필터 정책 관리

--- a/app/api/crawl/arcalive-parser.test.ts
+++ b/app/api/crawl/arcalive-parser.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { ARCALIVE_MINIMUM_ITEMS, parseArcaliveHtml } from "./arcalive-parser";
+
+const currentFixture = readFileSync(
+	new URL("./fixtures/arcalive-current.html", import.meta.url),
+	"utf8"
+);
+
+const arcaliveRow = (href: string, title: string) => `
+	<a class="vrow column" href="${href}">
+		<div class="vrow-inner"><div class="vrow-top"><span class="col-title">
+			<span class="badges"><span class="badge">테스트</span></span>
+			<span class="title">${title}</span>
+		</span></div></div>
+	</a>
+`;
+
+describe("parseArcaliveHtml", () => {
+	it("현재 실제 구조에서 최소 건수와 필수 필드를 추출한다", () => {
+		const result = parseArcaliveHtml(currentFixture);
+
+		expect(result.status).toBe("ok");
+		expect(result.items).toHaveLength(ARCALIVE_MINIMUM_ITEMS);
+		expect(result.warnings).toContainEqual(
+			expect.objectContaining({ code: "discarded-items", count: 2 })
+		);
+		for (const item of result.items) {
+			expect(item.url).toMatch(/^https:\/\/arca\.live\/b\/iloveanimal\/\d+$/);
+			expect(item.title?.trim()).toBeTruthy();
+			expect(item.host).toBe("https://arca.live");
+			expect(item.tag?.[0]).toBe("arcalive");
+		}
+	});
+
+	it("pagination query와 hash를 canonical URL에서 제거한다", () => {
+		const result = parseArcaliveHtml(currentFixture);
+
+		expect(result.items.at(-1)?.url).toBe("https://arca.live/b/iloveanimal/1010");
+	});
+
+	it("canonical URL 중복과 지원하지 않는 protocol을 제외한다", () => {
+		const result = parseArcaliveHtml(`
+			<div class="list-table table">
+				${arcaliveRow("/b/iloveanimal/1?p=1", "첫 게시물")}
+				${arcaliveRow("https://arca.live/b/iloveanimal/1?p=2#comments", "중복 게시물")}
+				${arcaliveRow("ftp://arca.live/b/iloveanimal/2", "지원하지 않는 링크")}
+			</div>
+		`);
+
+		expect(result.items.map((item) => item.url)).toEqual(["https://arca.live/b/iloveanimal/1"]);
+		expect(result.discardedCount).toBe(2);
+	});
+
+	it("공식 빈 목록 표시는 empty warning으로 구분한다", () => {
+		const result = parseArcaliveHtml(
+			'<div class="list-table table"><div class="list-empty">게시물이 없습니다.</div></div>'
+		);
+
+		expect(result).toMatchObject({
+			status: "empty",
+			items: [],
+			warnings: [{ code: "empty-list", count: 0 }],
+		});
+	});
+
+	it("목록 container 누락과 인식할 수 없는 빈 구조를 failure로 구분한다", () => {
+		expect(parseArcaliveHtml("<main>changed</main>")).toMatchObject({
+			status: "failure",
+			failure: { code: "missing-container" },
+		});
+		expect(parseArcaliveHtml('<div class="list-table table"></div>')).toMatchObject({
+			status: "failure",
+			failure: { code: "unrecognized-empty-state" },
+		});
+	});
+
+	it("잘못된 URL만 존재하면 failure, 일부만 잘못되면 warning으로 처리한다", () => {
+		const allInvalid = parseArcaliveHtml(`
+			<div class="list-table table">
+				${arcaliveRow("https://example.com/post/1", "외부 링크")}
+			</div>
+		`);
+		expect(allInvalid).toMatchObject({
+			status: "failure",
+			failure: { code: "all-items-invalid" },
+		});
+
+		const partial = parseArcaliveHtml(`
+			<div class="list-table table">
+				${arcaliveRow("/b/iloveanimal/1?p=2", "정상 링크")}
+				${arcaliveRow("not a url", "손상 링크")}
+			</div>
+		`);
+		expect(partial.status).toBe("ok");
+		expect(partial.items).toHaveLength(1);
+		expect(partial.warnings.map((warning) => warning.code)).toEqual([
+			"discarded-items",
+			"below-minimum-items",
+		]);
+	});
+});

--- a/app/api/crawl/arcalive-parser.ts
+++ b/app/api/crawl/arcalive-parser.ts
@@ -1,0 +1,99 @@
+import * as cheerio from "cheerio";
+import type { CrawlItemType } from "@/lib/type-defs";
+import {
+	createParserEmpty,
+	createParserFailure,
+	createParserSuccess,
+	type ParserOutcome,
+} from "./parser-contracts";
+
+const ARCALIVE_BASE_URL = "https://arca.live";
+const ARCALIVE_POST_PATH = /^\/b\/iloveanimal\/\d+$/;
+const EMPTY_LIST_TEXT = /(?:게시물|등록된 글|검색 결과)(?:이|가)?\s*없(?:습니다|어요)/;
+
+export const ARCALIVE_MINIMUM_ITEMS = 10;
+
+function parsePostUrl(href: string) {
+	try {
+		const url = new URL(href, ARCALIVE_BASE_URL);
+		if (
+			url.protocol !== "https:" ||
+			url.hostname !== "arca.live" ||
+			!ARCALIVE_POST_PATH.test(url.pathname)
+		) {
+			return null;
+		}
+
+		url.search = "";
+		url.hash = "";
+		return url.href;
+	} catch {
+		return null;
+	}
+}
+
+export function parseArcaliveHtml(html: string): ParserOutcome {
+	const $ = cheerio.load(html);
+	const container = $(".list-table.table").first();
+	if (container.length === 0) {
+		return createParserFailure({
+			code: "missing-container",
+			message: "Arcalive 목록 container를 찾지 못했습니다.",
+		});
+	}
+
+	const candidates = container.children(".vrow.column[href]");
+	const candidateCount = candidates.length;
+	if (candidateCount === 0) {
+		if (EMPTY_LIST_TEXT.test(container.text().replace(/\s+/g, " "))) {
+			return createParserEmpty("Arcalive");
+		}
+
+		return createParserFailure({
+			code: "unrecognized-empty-state",
+			message: "Arcalive 목록은 존재하지만 게시물 또는 공식 빈 목록 표시를 찾지 못했습니다.",
+		});
+	}
+
+	const items = new Map<string, CrawlItemType>();
+	let discardedCount = 0;
+	candidates.each((_index, element) => {
+		const href = $(element).attr("href");
+		const title = $(element).find(".title").text().replace(/\s+/g, " ").trim();
+		const url = href ? parsePostUrl(href) : null;
+		if (!url || !title || items.has(url)) {
+			discardedCount += 1;
+			return;
+		}
+
+		const badge = $(element)
+			.find(".vrow-top .col-title .badges")
+			.text()
+			.replace(/\s+/g, " ")
+			.trim();
+		items.set(url, {
+			url,
+			title,
+			description: "",
+			host: ARCALIVE_BASE_URL,
+			tag: badge ? ["arcalive", badge] : ["arcalive"],
+		});
+	});
+
+	if (items.size === 0) {
+		return createParserFailure({
+			code: "all-items-invalid",
+			message: "Arcalive 게시물 후보가 모두 URL 또는 필수 필드 검증에 실패했습니다.",
+			candidateCount,
+			discardedCount,
+		});
+	}
+
+	return createParserSuccess({
+		items: Array.from(items.values()),
+		candidateCount,
+		discardedCount,
+		minimumItems: ARCALIVE_MINIMUM_ITEMS,
+		source: "Arcalive",
+	});
+}

--- a/app/api/crawl/arcalive.ts
+++ b/app/api/crawl/arcalive.ts
@@ -1,22 +1,24 @@
-import * as cheerio from "cheerio";
 import type { CrawlItemType } from "@/lib/type-defs";
+import { parseArcaliveHtml } from "./arcalive-parser";
 import {
 	type CrawlFailure,
 	type CrawlSourceResult,
+	type CrawlWarning,
 	getErrorMessage,
 	isTimeoutError,
 } from "./contracts";
 import { fetchWithTimeout } from "./fetch-with-timeout";
 import { debugLog } from "./logger";
+import { adaptParserOutcome } from "./parser-adapter";
 
 export async function crawlArcalive(): Promise<CrawlSourceResult> {
 	debugLog("[Arcalive] 크롤링 시작");
 
-	const baseUrl = "https://arca.live";
 	const target = "https://arca.live/b/iloveanimal?mode=best";
 	const targetList = Array.from({ length: 3 }, (_, index) => `${target}&p=${index + 1}`);
 	const detectedList: CrawlItemType[][] = [];
 	const failures: CrawlFailure[] = [];
+	const warnings: CrawlWarning[] = [];
 	let succeeded = 0;
 
 	for (let index = 0; index < targetList.length; index += 1) {
@@ -29,38 +31,22 @@ export async function crawlArcalive(): Promise<CrawlSourceResult> {
 				throw new Error(`HTTP ${response.status} ${response.statusText}`);
 			}
 
-			const text = await response.text();
-			const $ = cheerio.load(text);
-			const items = $(".list-table.table")
-				.children(".vrow.column")
-				.filter((_itemIndex, element) => {
-					return (
-						$(element).attr("href") !== undefined && $(element).find(".title").text().trim() !== ""
-					);
-				})
-				.map((_itemIndex, element) => {
-					const badge = $(element)
-						.find(".vrow-inner .vrow-top .vcol.col-title .badges")
-						.text()
-						.trim();
-					const href = $(element).attr("href") ?? "";
+			const outcome = parseArcaliveHtml(await response.text());
+			const parsed = adaptParserOutcome(url, outcome);
+			warnings.push(...parsed.warnings);
+			debugLog(
+				`[Arcalive] 페이지 ${index + 1} parser=${outcome.status} candidates=${outcome.candidateCount} valid=${outcome.items.length} discarded=${outcome.discardedCount}`
+			);
+			if (parsed.failure) {
+				failures.push(parsed.failure);
+				continue;
+			}
 
-					return {
-						url: `${baseUrl}${href.replace(/\?mode=best&p=\d+/, "")}`,
-						title: $(element).find(".title").text().trim(),
-						description: "",
-						host: baseUrl,
-						tag: badge ? ["arcalive", badge] : ["arcalive"],
-					} satisfies CrawlItemType;
-				})
-				.get();
-
-			detectedList.push(items);
+			detectedList.push(parsed.items);
 			succeeded += 1;
-			debugLog(`[Arcalive] 페이지 ${index + 1} 아이템 ${items.length}개 추출 완료`);
 		} catch (error) {
 			const message = getErrorMessage(error);
-			failures.push({ url, message, timeout: isTimeoutError(error) });
+			failures.push({ url, message, kind: "network", timeout: isTimeoutError(error) });
 			console.error(`[Arcalive] 페이지 ${index + 1} 크롤링 실패: ${message}`);
 		}
 	}
@@ -73,5 +59,6 @@ export async function crawlArcalive(): Promise<CrawlSourceResult> {
 		attempted: targetList.length,
 		succeeded,
 		failures,
+		warnings,
 	};
 }

--- a/app/api/crawl/battlepage-parser.test.ts
+++ b/app/api/crawl/battlepage-parser.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { BATTLEPAGE_MINIMUM_ITEMS, parseBattlepageHtml } from "./battlepage-parser";
+
+const currentFixture = readFileSync(
+	new URL("./fixtures/battlepage-current.html", import.meta.url),
+	"utf8"
+);
+const emptyFixture = readFileSync(
+	new URL("./fixtures/battlepage-empty.html", import.meta.url),
+	"utf8"
+);
+
+const battlepageRow = (href: string, title: string) => `
+	<div class="bp_subject" title="${title}"><a href="${href}">${title}</a></div>
+`;
+
+describe("parseBattlepageHtml", () => {
+	it("현재 실제 구조에서 최소 건수와 필수 필드를 추출한다", () => {
+		const result = parseBattlepageHtml(currentFixture);
+
+		expect(result.status).toBe("ok");
+		expect(result.items).toHaveLength(BATTLEPAGE_MINIMUM_ITEMS);
+		for (const item of result.items) {
+			expect(item.url).toMatch(
+				/^https:\/\/v12\.battlepage\.com\/\?\?=Board\.(?:Humor|ETC)\.View&no=\d+$/
+			);
+			expect(item.url).not.toContain("page=");
+			expect(item.title?.trim()).toBeTruthy();
+			expect(item.host).toBe("https://v12.battlepage.com");
+			expect(item.tag).toEqual(["battlepage"]);
+		}
+	});
+
+	it("실제 빈 페이지 marker를 empty warning으로 구분한다", () => {
+		expect(parseBattlepageHtml(emptyFixture)).toMatchObject({
+			status: "empty",
+			items: [],
+			warnings: [{ code: "empty-list", count: 0 }],
+		});
+	});
+
+	it("page parameter 제거 후 중복 URL과 지원하지 않는 protocol을 제외한다", () => {
+		const result = parseBattlepageHtml(`
+			<div class="ListTable">
+				${battlepageRow("/??=Board.Humor.View&page=1&no=10", "첫 게시물")}
+				${battlepageRow("/??=Board.Humor.View&page=2&no=10", "중복 게시물")}
+				${battlepageRow("ftp://v12.battlepage.com/??=Board.Humor.View&no=11", "지원하지 않는 링크")}
+			</div>
+		`);
+
+		expect(result.items.map((item) => item.url)).toEqual([
+			"https://v12.battlepage.com/??=Board.Humor.View&no=10",
+		]);
+		expect(result.discardedCount).toBe(2);
+	});
+
+	it("container 누락과 marker 없는 빈 구조를 parser failure로 처리한다", () => {
+		expect(parseBattlepageHtml("<main>changed</main>")).toMatchObject({
+			status: "failure",
+			failure: { code: "missing-container" },
+		});
+		expect(parseBattlepageHtml('<div class="ListTable"></div>')).toMatchObject({
+			status: "failure",
+			failure: { code: "unrecognized-empty-state" },
+		});
+	});
+
+	it("외부·손상 URL을 제외하고 모든 후보가 잘못되면 failure로 처리한다", () => {
+		const result = parseBattlepageHtml(`
+			<div class="ListTable">
+				${battlepageRow("https://example.com/post/1", "외부 링크")}
+				${battlepageRow("/??=Board.Unknown.View&no=1", "잘못된 게시판")}
+			</div>
+		`);
+
+		expect(result).toMatchObject({
+			status: "failure",
+			candidateCount: 2,
+			discardedCount: 2,
+			failure: { code: "all-items-invalid" },
+		});
+	});
+
+	it("최소 건수 미달과 일부 제외를 warning으로 반환한다", () => {
+		const result = parseBattlepageHtml(`
+			<div class="ListTable">
+				${battlepageRow("/??=Board.Humor.View&page=2&no=10", "정상 게시물")}
+				${battlepageRow("broken", "손상 URL")}
+			</div>
+		`);
+
+		expect(result.status).toBe("ok");
+		expect(result.items).toHaveLength(1);
+		expect(result.warnings.map((warning) => warning.code)).toEqual([
+			"discarded-items",
+			"below-minimum-items",
+		]);
+	});
+});

--- a/app/api/crawl/battlepage-parser.ts
+++ b/app/api/crawl/battlepage-parser.ts
@@ -1,0 +1,98 @@
+import * as cheerio from "cheerio";
+import type { CrawlItemType } from "@/lib/type-defs";
+import {
+	createParserEmpty,
+	createParserFailure,
+	createParserSuccess,
+	type ParserOutcome,
+} from "./parser-contracts";
+
+const BATTLEPAGE_BASE_URL = "https://v12.battlepage.com";
+const ALLOWED_BOARDS = new Set(["Board.Humor.View", "Board.ETC.View"]);
+const EMPTY_LIST_TEXT = /검색된 게시물이 없습니다/;
+
+export const BATTLEPAGE_MINIMUM_ITEMS = 5;
+
+function parsePostUrl(href: string) {
+	try {
+		const url = new URL(href, BATTLEPAGE_BASE_URL);
+		const board = url.searchParams.get("?");
+		const postNumber = url.searchParams.get("no");
+		if (
+			url.protocol !== "https:" ||
+			url.hostname !== "v12.battlepage.com" ||
+			url.pathname !== "/" ||
+			!board ||
+			!ALLOWED_BOARDS.has(board) ||
+			!postNumber ||
+			!/^\d+$/.test(postNumber)
+		) {
+			return null;
+		}
+
+		return `${BATTLEPAGE_BASE_URL}/??=${board}&no=${postNumber}`;
+	} catch {
+		return null;
+	}
+}
+
+export function parseBattlepageHtml(html: string): ParserOutcome {
+	const $ = cheerio.load(html);
+	const containers = $(".ListTable");
+	if (containers.length === 0) {
+		return createParserFailure({
+			code: "missing-container",
+			message: "Battlepage 목록 container를 찾지 못했습니다.",
+		});
+	}
+
+	const candidates = containers.find(".bp_subject[title]");
+	const candidateCount = candidates.length;
+	if (candidateCount === 0) {
+		if (EMPTY_LIST_TEXT.test(containers.text().replace(/\s+/g, " "))) {
+			return createParserEmpty("Battlepage");
+		}
+
+		return createParserFailure({
+			code: "unrecognized-empty-state",
+			message: "Battlepage 목록은 존재하지만 게시물 또는 공식 빈 목록 표시를 찾지 못했습니다.",
+		});
+	}
+
+	const items = new Map<string, CrawlItemType>();
+	let discardedCount = 0;
+	candidates.each((_index, element) => {
+		const href = $(element).find("a[href]").first().attr("href");
+		const title = ($(element).attr("title") ?? "").replace(/\s+/g, " ").trim();
+		const url = href ? parsePostUrl(href) : null;
+		if (!url || !title || items.has(url)) {
+			discardedCount += 1;
+			return;
+		}
+
+		items.set(url, {
+			url,
+			title,
+			description: "",
+			host: BATTLEPAGE_BASE_URL,
+			tag: ["battlepage"],
+		});
+	});
+
+	if (items.size === 0) {
+		return createParserFailure({
+			code: "all-items-invalid",
+			message: "Battlepage 게시물 후보가 모두 URL 또는 필수 필드 검증에 실패했습니다.",
+			candidateCount,
+			discardedCount,
+		});
+	}
+
+	return createParserSuccess({
+		items: Array.from(items.values()),
+		candidateCount,
+		discardedCount,
+		minimumItems: BATTLEPAGE_MINIMUM_ITEMS,
+		source: "Battlepage",
+	});
+}

--- a/app/api/crawl/battlepage.ts
+++ b/app/api/crawl/battlepage.ts
@@ -1,16 +1,19 @@
-import * as cheerio from "cheerio";
 import type { CrawlItemType } from "@/lib/type-defs";
+import { parseBattlepageHtml } from "./battlepage-parser";
 import {
 	type CrawlFailure,
 	type CrawlSourceResult,
+	type CrawlWarning,
 	getErrorMessage,
 	isTimeoutError,
 } from "./contracts";
 import { fetchWithTimeout } from "./fetch-with-timeout";
 import { debugLog } from "./logger";
+import { adaptParserOutcome } from "./parser-adapter";
 
 interface BattlepagePageResult {
 	items: CrawlItemType[];
+	warnings: CrawlWarning[];
 	failure?: CrawlFailure;
 }
 
@@ -36,43 +39,33 @@ export async function crawlBattlepage(): Promise<CrawlSourceResult> {
 					throw new Error(`HTTP ${response.status} ${response.statusText}`);
 				}
 
-				const text = await response.text();
-				const $ = cheerio.load(text);
-				const mappedItems = $(".ListTable div")
-					.map((_itemIndex, element) => {
-						const href = $(element).find("a").attr("href");
-						if (!href) {
-							return null;
-						}
-
-						return {
-							url: `${baseUrl}${href.replace(/&page=\d+/, "")}`,
-							title: $(element).find(".bp_subject").attr("title") ?? "",
-							description: "",
-							host: baseUrl,
-							tag: ["battlepage"],
-						} satisfies CrawlItemType;
-					})
-					.get();
-				const items: CrawlItemType[] = mappedItems.flatMap((item) => (item ? [item] : []));
-
-				debugLog(`[Battlepage] URL ${index + 1} 아이템 ${items.length}개 추출 완료`);
-				return { items };
+				const outcome = parseBattlepageHtml(await response.text());
+				const parsed = adaptParserOutcome(url, outcome);
+				debugLog(
+					`[Battlepage] URL ${index + 1} parser=${outcome.status} candidates=${outcome.candidateCount} valid=${outcome.items.length} discarded=${outcome.discardedCount}`
+				);
+				return parsed;
 			} catch (error) {
 				const message = getErrorMessage(error);
 				console.error(`[Battlepage] URL ${index + 1} 크롤링 실패: ${message}`);
-				return { items: [], failure: { url, message, timeout: isTimeoutError(error) } };
+				return {
+					items: [],
+					warnings: [],
+					failure: { url, message, kind: "network", timeout: isTimeoutError(error) },
+				};
 			}
 		})
 	);
 
 	const failures = results.flatMap((result) => (result.failure ? [result.failure] : []));
 	const items = results.flatMap((result) => result.items);
+	const warnings = results.flatMap((result) => result.warnings);
 
 	return {
 		items,
 		attempted: targetList.length,
 		succeeded: targetList.length - failures.length,
 		failures,
+		warnings,
 	};
 }

--- a/app/api/crawl/contracts.ts
+++ b/app/api/crawl/contracts.ts
@@ -7,7 +7,15 @@ export type CrawlTarget = (typeof CRAWL_TARGETS)[number];
 export interface CrawlFailure {
 	url: string;
 	message: string;
+	kind: "network" | "parser";
 	timeout?: boolean;
+}
+
+export interface CrawlWarning {
+	url: string;
+	code: "empty-list" | "below-minimum-items" | "discarded-items";
+	message: string;
+	count: number;
 }
 
 export interface CrawlSourceResult {
@@ -15,6 +23,7 @@ export interface CrawlSourceResult {
 	attempted: number;
 	succeeded: number;
 	failures: CrawlFailure[];
+	warnings: CrawlWarning[];
 }
 
 export function isCrawlTarget(value: unknown): value is CrawlTarget {

--- a/app/api/crawl/fixtures/README.md
+++ b/app/api/crawl/fixtures/README.md
@@ -1,0 +1,11 @@
+# 크롤러 parser fixtures
+
+아래 fixture는 2026-07-21 공개 응답에서 parser에 필요한 DOM/JSON 구조만 추출한 스냅샷입니다.
+게시물 내용, 작성자, 시간, 광고, 동적 token은 테스트용 값으로 정제했습니다.
+
+- `arcalive-current.html`: `https://arca.live/b/iloveanimal?mode=best&p=1`
+- `battlepage-current.html`: `https://v12.battlepage.com/??=Board.Humor.Table&page=1`
+- `battlepage-empty.html`: `https://v12.battlepage.com/??=Board.Humor.Table&page=9999`
+- `insagirl-current.json`: `https://insagirl-hrm.appspot.com/json2/1/1/2/`
+
+CI에서는 fixture만 사용합니다. fixture를 갱신할 때는 실제 응답 구조와 source URL을 다시 확인합니다.

--- a/app/api/crawl/fixtures/arcalive-current.html
+++ b/app/api/crawl/fixtures/arcalive-current.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="ko">
+	<body>
+		<div class="list-table table">
+			<a class="vrow column" href="https://arca.live/b/other/1"><div class="vrow-inner"><span class="title">다른 채널</span></div></a>
+			<a class="vrow column" href="/b/iloveanimal/1000?mode=best&amp;p=1"><div class="vrow-inner"><div class="vrow-top"><span class="vcol col-title"><span class="badges"></span><span class="info">제목 없음</span></span></div></div></a>
+			<a class="vrow column" href="/b/iloveanimal/1001?mode=best&amp;p=1"><div class="vrow-inner"><div class="vrow-top"><span class="vcol col-title"><span class="badges"><span class="badge badge-success">유머•렉카</span></span><span class="title">테스트 게시물 1</span></span></div></div></a>
+			<a class="vrow column" href="/b/iloveanimal/1002?mode=best&amp;p=1"><div class="vrow-inner"><div class="vrow-top"><span class="vcol col-title"><span class="badges"><span class="badge badge-success">애니•만화방</span></span><span class="title">테스트 게시물 2</span></span></div></div></a>
+			<a class="vrow column" href="/b/iloveanimal/1003?mode=best&amp;p=1"><div class="vrow-inner"><div class="vrow-top"><span class="vcol col-title"><span class="badges"><span class="badge">유머•렉카</span></span><span class="title">테스트 게시물 3</span></span></div></div></a>
+			<a class="vrow column" href="/b/iloveanimal/1004?mode=best&amp;p=1"><div class="vrow-inner"><div class="vrow-top"><span class="vcol col-title"><span class="badges"><span class="badge">유머•렉카</span></span><span class="title">테스트 게시물 4</span></span></div></div></a>
+			<a class="vrow column" href="/b/iloveanimal/1005?mode=best&amp;p=1"><div class="vrow-inner"><div class="vrow-top"><span class="vcol col-title"><span class="badges"><span class="badge">유머•렉카</span></span><span class="title">테스트 게시물 5</span></span></div></div></a>
+			<a class="vrow column" href="/b/iloveanimal/1006?mode=best&amp;p=1"><div class="vrow-inner"><div class="vrow-top"><span class="vcol col-title"><span class="badges"><span class="badge">유머•렉카</span></span><span class="title">테스트 게시물 6</span></span></div></div></a>
+			<a class="vrow column" href="/b/iloveanimal/1007?mode=best&amp;p=1"><div class="vrow-inner"><div class="vrow-top"><span class="vcol col-title"><span class="badges"><span class="badge">유머•렉카</span></span><span class="title">테스트 게시물 7</span></span></div></div></a>
+			<a class="vrow column" href="/b/iloveanimal/1008?mode=best&amp;p=1"><div class="vrow-inner"><div class="vrow-top"><span class="vcol col-title"><span class="badges"><span class="badge">유머•렉카</span></span><span class="title">테스트 게시물 8</span></span></div></div></a>
+			<a class="vrow column" href="/b/iloveanimal/1009?mode=best&amp;p=1"><div class="vrow-inner"><div class="vrow-top"><span class="vcol col-title"><span class="badges"><span class="badge">유머•렉카</span></span><span class="title">테스트 게시물 9</span></span></div></div></a>
+			<a class="vrow column" href="/b/iloveanimal/1010?mode=best&amp;p=1#comments"><div class="vrow-inner"><div class="vrow-top"><span class="vcol col-title"><span class="badges"><span class="badge">유머•렉카</span></span><span class="title">테스트 게시물 10</span></span></div></div></a>
+		</div>
+	</body>
+</html>

--- a/app/api/crawl/fixtures/battlepage-current.html
+++ b/app/api/crawl/fixtures/battlepage-current.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="ko">
+	<body>
+		<div class="ListTable">
+			<table>
+				<tbody>
+					<tr><td class="bp_subject" title="테스트 게시물 1"><span class="el subject"><a href="/??=Board.Humor.View&amp;page=1&amp;no=2001"><span class="search_title">테스트 게시물 1</span></a></span></td></tr>
+					<tr><td class="bp_subject" title="테스트 게시물 2"><span class="el subject"><a href="/??=Board.Humor.View&amp;page=1&amp;no=2002"><span class="search_title">테스트 게시물 2</span></a></span></td></tr>
+					<tr><td class="bp_subject" title="테스트 게시물 3"><span class="el subject"><a href="/??=Board.Humor.View&amp;page=1&amp;no=2003"><span class="search_title">테스트 게시물 3</span></a></span></td></tr>
+					<tr><td class="bp_subject" title="테스트 게시물 4"><span class="el subject"><a href="/??=Board.ETC.View&amp;page=1&amp;no=2004"><span class="search_title">테스트 게시물 4</span></a></span></td></tr>
+					<tr><td class="bp_subject" title="테스트 게시물 5"><span class="el subject"><a href="/??=Board.ETC.View&amp;page=1&amp;no=2005"><span class="search_title">테스트 게시물 5</span></a></span></td></tr>
+					<tr><td class="bp_subject" title="외부 링크"><span class="el subject"><a href="https://example.com/post/1">외부 링크</a></span></td></tr>
+				</tbody>
+			</table>
+		</div>
+	</body>
+</html>

--- a/app/api/crawl/fixtures/battlepage-empty.html
+++ b/app/api/crawl/fixtures/battlepage-empty.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko">
+	<body>
+		<div class="ListTable">
+			<ul class="ListTable">
+				<li class="bp_no_title"></li>
+				<li class="bp_subject_title"></li>
+			</ul>
+			<div class="nolist">검색된 게시물이 없습니다.</div>
+		</div>
+	</body>
+</html>

--- a/app/api/crawl/fixtures/insagirl-current.json
+++ b/app/api/crawl/fixtures/insagirl-current.json
@@ -1,0 +1,26 @@
+{
+	"v": [
+		"1|syncwatch|{\"t\":\"yb\"}",
+		"2|tester|테스트 제목 1 https://example.com/posts/1",
+		"3|tester|테스트 제목 2 https://example.com/posts/2",
+		"4|tester|테스트 제목 3 https://example.com/posts/3",
+		"5|tester|테스트 제목 4 https://example.com/posts/4",
+		"6|tester|테스트 제목 5 https://example.com/posts/5",
+		"7|tester|테스트 제목 6 https://example.com/posts/6",
+		"8|tester|테스트 제목 7 https://example.com/posts/7",
+		"9|tester|테스트 제목 8 https://example.com/posts/8",
+		"10|tester|테스트 제목 9 https://example.com/posts/9",
+		"11|tester|테스트 제목 10 https://example.com/posts/10",
+		"12|tester|테스트 제목 11 https://example.com/posts/11",
+		"13|tester|테스트 제목 12 https://example.com/posts/12",
+		"14|tester|테스트 제목 13 https://example.com/posts/13",
+		"15|tester|테스트 제목 14 https://example.com/posts/14",
+		"16|tester|테스트 제목 15 https://example.com/posts/15",
+		"17|tester|테스트 제목 16 https://example.com/posts/16",
+		"18|tester|테스트 제목 17 https://example.com/posts/17",
+		"19|tester|테스트 제목 18 https://example.com/posts/18",
+		"20|tester|테스트 제목 19 https://example.com/posts/19",
+		"21|tester|테스트 제목 20 https://example.com/posts/20",
+		"22|tester|중복 링크 https://example.com/posts/20"
+	]
+}

--- a/app/api/crawl/insagirl-parser.test.ts
+++ b/app/api/crawl/insagirl-parser.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { INSAGIRL_MINIMUM_ITEMS, parseInsagirlPayload } from "./insagirl-parser";
+
+const currentFixture = JSON.parse(
+	readFileSync(new URL("./fixtures/insagirl-current.json", import.meta.url), "utf8")
+) as unknown;
+
+describe("parseInsagirlPayload", () => {
+	it("현재 실제 JSON 구조에서 최소 건수와 필수 필드를 추출한다", () => {
+		const result = parseInsagirlPayload(currentFixture);
+
+		expect(result.status).toBe("ok");
+		expect(result.items).toHaveLength(INSAGIRL_MINIMUM_ITEMS);
+		expect(result.warnings).toContainEqual(
+			expect.objectContaining({ code: "discarded-items", count: 1 })
+		);
+		for (const item of result.items) {
+			expect(item.url).toMatch(/^https?:\/\//);
+			expect(item.title?.trim()).toBeTruthy();
+			expect(item.host?.trim()).toBeTruthy();
+			expect(item.tag).toEqual(["insagirl"]);
+		}
+		expect(new Set(result.items.map((item) => item.url)).size).toBe(result.items.length);
+	});
+
+	it("빈 배열과 syncwatch 전용 응답을 정상 empty로 구분한다", () => {
+		expect(parseInsagirlPayload({ v: [] })).toMatchObject({
+			status: "empty",
+			warnings: [{ code: "empty-list" }],
+		});
+		expect(parseInsagirlPayload({ v: ["1|syncwatch|payload"] })).toMatchObject({
+			status: "empty",
+			warnings: [{ code: "empty-list" }],
+		});
+	});
+
+	it("v 배열이 없는 구조 변경을 invalid-payload로 처리한다", () => {
+		expect(parseInsagirlPayload({ items: [] })).toMatchObject({
+			status: "failure",
+			failure: { code: "invalid-payload" },
+		});
+		expect(parseInsagirlPayload("invalid")).toMatchObject({
+			status: "failure",
+			failure: { code: "invalid-payload" },
+		});
+	});
+
+	it("필수 title이 없는 URL 후보만 있으면 all-items-invalid로 처리한다", () => {
+		const result = parseInsagirlPayload({ v: ["1|tester|https://example.com/only-url"] });
+
+		expect(result).toMatchObject({
+			status: "failure",
+			candidateCount: 1,
+			discardedCount: 1,
+			failure: { code: "all-items-invalid" },
+		});
+	});
+
+	it("일부 잘못된 후보는 제외하고 warning과 유효 항목을 보존한다", () => {
+		const result = parseInsagirlPayload({
+			v: [
+				"1|tester|정상 제목 https://example.com/valid#fragment",
+				"2|tester|https://example.com/only-url",
+				42,
+			],
+		});
+
+		expect(result.status).toBe("ok");
+		expect(result.items).toEqual([
+			expect.objectContaining({
+				url: "https://example.com/valid",
+				title: "정상 제목",
+				host: "example.com",
+			}),
+		]);
+		expect(result.warnings.map((warning) => warning.code)).toEqual([
+			"discarded-items",
+			"below-minimum-items",
+		]);
+	});
+});

--- a/app/api/crawl/insagirl-parser.ts
+++ b/app/api/crawl/insagirl-parser.ts
@@ -1,0 +1,114 @@
+import * as linkify from "linkifyjs";
+import type { CrawlItemType } from "@/lib/type-defs";
+import {
+	createParserEmpty,
+	createParserFailure,
+	createParserSuccess,
+	type ParserOutcome,
+} from "./parser-contracts";
+
+export const INSAGIRL_MINIMUM_ITEMS = 20;
+
+function parseDetectedUrl(href: string) {
+	try {
+		const url = new URL(href);
+		if ((url.protocol !== "http:" && url.protocol !== "https:") || !url.hostname) {
+			return null;
+		}
+
+		url.hash = "";
+		return url;
+	} catch {
+		return null;
+	}
+}
+
+function collectRecordItems(rawItem: unknown, items: Map<string, CrawlItemType>) {
+	if (typeof rawItem !== "string") {
+		return { candidateCount: 0, discardedCount: 1, nonSyncRecordCount: 1 };
+	}
+
+	const segments = rawItem.split("|");
+	if (segments[1] === "syncwatch") {
+		return { candidateCount: 0, discardedCount: 0, nonSyncRecordCount: 0 };
+	}
+
+	const rawString = segments.slice(2).join("|").trim();
+	if (!rawString) {
+		return { candidateCount: 0, discardedCount: 1, nonSyncRecordCount: 1 };
+	}
+
+	const detectedUrls = linkify.find(rawString);
+	const title = detectedUrls
+		.reduce((text, detectedUrl) => text.replace(detectedUrl.value, ""), rawString)
+		.replace(/\s+/g, " ")
+		.trim();
+	let discardedCount = 0;
+	for (const detectedUrl of detectedUrls) {
+		const url = parseDetectedUrl(detectedUrl.href);
+		if (!url || !title || items.has(url.href)) {
+			discardedCount += 1;
+			continue;
+		}
+
+		items.set(url.href, {
+			url: url.href,
+			title,
+			description: "",
+			host: url.hostname,
+			tag: ["insagirl"],
+		});
+	}
+
+	return {
+		candidateCount: detectedUrls.length,
+		discardedCount,
+		nonSyncRecordCount: 1,
+	};
+}
+
+export function parseInsagirlPayload(payload: unknown): ParserOutcome {
+	if (!payload || typeof payload !== "object" || !("v" in payload) || !Array.isArray(payload.v)) {
+		return createParserFailure({
+			code: "invalid-payload",
+			message: "Insagirl 응답의 v 배열을 찾지 못했습니다.",
+		});
+	}
+
+	if (payload.v.length === 0) {
+		return createParserEmpty("Insagirl");
+	}
+
+	const items = new Map<string, CrawlItemType>();
+	let candidateCount = 0;
+	let discardedCount = 0;
+	let nonSyncRecordCount = 0;
+
+	for (const rawItem of payload.v) {
+		const metrics = collectRecordItems(rawItem, items);
+		candidateCount += metrics.candidateCount;
+		discardedCount += metrics.discardedCount;
+		nonSyncRecordCount += metrics.nonSyncRecordCount;
+	}
+
+	if (nonSyncRecordCount === 0) {
+		return createParserEmpty("Insagirl");
+	}
+
+	if (items.size === 0) {
+		return createParserFailure({
+			code: "all-items-invalid",
+			message: "Insagirl 게시물 후보가 모두 URL 또는 필수 필드 검증에 실패했습니다.",
+			candidateCount,
+			discardedCount,
+		});
+	}
+
+	return createParserSuccess({
+		items: Array.from(items.values()),
+		candidateCount,
+		discardedCount,
+		minimumItems: INSAGIRL_MINIMUM_ITEMS,
+		source: "Insagirl",
+	});
+}

--- a/app/api/crawl/insagirl.ts
+++ b/app/api/crawl/insagirl.ts
@@ -1,16 +1,19 @@
-import * as linkify from "linkifyjs";
 import type { CrawlItemType } from "@/lib/type-defs";
 import {
 	type CrawlFailure,
 	type CrawlSourceResult,
+	type CrawlWarning,
 	getErrorMessage,
 	isTimeoutError,
 } from "./contracts";
 import { fetchWithTimeout } from "./fetch-with-timeout";
+import { parseInsagirlPayload } from "./insagirl-parser";
 import { debugLog } from "./logger";
+import { adaptParserOutcome } from "./parser-adapter";
 
 interface InsagirlPageResult {
 	items: CrawlItemType[];
+	warnings: CrawlWarning[];
 	failure?: CrawlFailure;
 }
 
@@ -26,50 +29,28 @@ async function crawlInsagirlTarget(url: string, index: number): Promise<Insagirl
 			throw new Error(`HTTP ${response.status} ${response.statusText}`);
 		}
 
-		const json = (await response.json()) as { v?: unknown };
-		if (!Array.isArray(json.v)) {
-			throw new Error("Unexpected JSON response shape");
+		const responseBody = await response.text();
+		let payload: unknown = null;
+		try {
+			payload = JSON.parse(responseBody) as unknown;
+		} catch {
+			// 손상된 JSON도 네트워크 오류가 아닌 parser failure로 분류합니다.
 		}
 
-		const items: CrawlItemType[] = [];
-		for (const rawItem of json.v) {
-			if (typeof rawItem !== "string") {
-				continue;
-			}
-
-			const segments = rawItem.split("|");
-			if (segments[1] === "syncwatch" || !segments[2]) {
-				continue;
-			}
-
-			const rawString = segments[2];
-			const urls = linkify.find(rawString);
-			const title = urls
-				.reduce((text, detectedUrl) => text.replace(detectedUrl.value, ""), rawString)
-				.replace(/\s+/g, " ")
-				.trim();
-
-			for (const detectedUrl of urls) {
-				try {
-					items.push({
-						url: detectedUrl.href,
-						title,
-						description: "",
-						host: new URL(detectedUrl.href).hostname,
-						tag: ["insagirl"],
-					});
-				} catch (error) {
-					debugLog("[Insagirl] 잘못된 URL 제외", getErrorMessage(error));
-				}
-			}
-		}
-
-		debugLog(`[Insagirl] URL ${index + 1} 아이템 ${items.length}개 추출 완료`);
-		return { items };
+		const outcome = parseInsagirlPayload(payload);
+		const parsed = adaptParserOutcome(url, outcome);
+		debugLog(
+			`[Insagirl] URL ${index + 1} parser=${outcome.status} candidates=${outcome.candidateCount} valid=${outcome.items.length} discarded=${outcome.discardedCount}`
+		);
+		return parsed;
 	} catch (error) {
 		const message = getErrorMessage(error);
 		console.error(`[Insagirl] URL ${index + 1} 크롤링 실패: ${message}`);
-		return { items: [], failure: { url, message, timeout: isTimeoutError(error) } };
+		return {
+			items: [],
+			warnings: [],
+			failure: { url, message, kind: "network", timeout: isTimeoutError(error) },
+		};
 	}
 }
 
@@ -82,6 +63,7 @@ export async function crawlInsagirl(): Promise<CrawlSourceResult> {
 	const results = await Promise.all(targets.map(crawlInsagirlTarget));
 
 	const failures = results.flatMap((result) => (result.failure ? [result.failure] : []));
+	const warnings = results.flatMap((result) => result.warnings);
 	const dedupedItems = new Map<string, CrawlItemType>();
 	for (const item of results.flatMap((result) => result.items)) {
 		if (!dedupedItems.has(item.url)) {
@@ -94,5 +76,6 @@ export async function crawlInsagirl(): Promise<CrawlSourceResult> {
 		attempted: targets.length,
 		succeeded: targets.length - failures.length,
 		failures,
+		warnings,
 	};
 }

--- a/app/api/crawl/issuelink.ts
+++ b/app/api/crawl/issuelink.ts
@@ -2,6 +2,7 @@ import type { CrawlItemType } from "@/lib/type-defs";
 import {
 	type CrawlFailure,
 	type CrawlSourceResult,
+	type CrawlWarning,
 	getErrorMessage,
 	isTimeoutError,
 } from "./contracts";
@@ -13,6 +14,7 @@ type Condition = "adj" | "read" | "click";
 
 interface IssuelinkPageResult {
 	items: CrawlItemType[];
+	warnings: CrawlWarning[];
 	failure?: CrawlFailure;
 }
 
@@ -48,17 +50,27 @@ async function getItemsByCondition(condition: Condition): Promise<IssuelinkPageR
 				?.replace(/\s+/g, " ")
 				.trim()
 				.slice(0, 80);
-			throw new Error(
-				`IssueLink response contained no community items (bytes=${html.length}, title=${title || "none"})`
-			);
+			return {
+				items: [],
+				warnings: [],
+				failure: {
+					url,
+					kind: "parser",
+					message: `IssueLink response contained no community items (bytes=${html.length}, title=${title || "none"})`,
+				},
+			};
 		}
 
 		debugLog(`[Issuelink] ${condition} 조건 아이템 ${items.length}개 추출 완료`);
-		return { items };
+		return { items, warnings: [] };
 	} catch (error) {
 		const message = getErrorMessage(error);
 		console.error(`[Issuelink] ${condition} 조건 크롤링 실패: ${message}`);
-		return { items: [], failure: { url, message, timeout: isTimeoutError(error) } };
+		return {
+			items: [],
+			warnings: [],
+			failure: { url, message, kind: "network", timeout: isTimeoutError(error) },
+		};
 	}
 }
 
@@ -71,6 +83,7 @@ export async function crawlIssuelink(): Promise<CrawlSourceResult> {
 	}
 
 	const failures = results.flatMap((result) => (result.failure ? [result.failure] : []));
+	const warnings = results.flatMap((result) => result.warnings);
 	const dedupedItems = new Map<string, CrawlItemType>();
 	for (const item of results.flatMap((result) => result.items)) {
 		if (!dedupedItems.has(item.url)) {
@@ -83,5 +96,6 @@ export async function crawlIssuelink(): Promise<CrawlSourceResult> {
 		attempted: conditions.length,
 		succeeded: conditions.length - failures.length,
 		failures,
+		warnings,
 	};
 }

--- a/app/api/crawl/parser-adapter.ts
+++ b/app/api/crawl/parser-adapter.ts
@@ -1,0 +1,28 @@
+import type { CrawlFailure, CrawlWarning } from "./contracts";
+import type { ParserOutcome } from "./parser-contracts";
+
+export function adaptParserOutcome(url: string, outcome: ParserOutcome) {
+	const warnings: CrawlWarning[] = outcome.warnings.map((warning) => ({
+		url,
+		...warning,
+	}));
+
+	if (outcome.status === "failure") {
+		return {
+			items: [],
+			succeeded: false,
+			warnings,
+			failure: {
+				url,
+				kind: "parser",
+				message: outcome.failure?.message ?? "Parser failure",
+			} satisfies CrawlFailure,
+		};
+	}
+
+	return {
+		items: outcome.items,
+		succeeded: true,
+		warnings,
+	};
+}

--- a/app/api/crawl/parser-contracts.ts
+++ b/app/api/crawl/parser-contracts.ts
@@ -1,0 +1,113 @@
+import type { CrawlItemType } from "@/lib/type-defs";
+
+export type ParserWarningCode = "empty-list" | "below-minimum-items" | "discarded-items";
+
+export type ParserFailureCode =
+	| "missing-container"
+	| "invalid-payload"
+	| "unrecognized-empty-state"
+	| "all-items-invalid";
+
+export interface ParserWarning {
+	code: ParserWarningCode;
+	message: string;
+	count: number;
+}
+
+export interface ParserFailure {
+	code: ParserFailureCode;
+	message: string;
+}
+
+export interface ParserOutcome {
+	status: "ok" | "empty" | "failure";
+	items: CrawlItemType[];
+	candidateCount: number;
+	discardedCount: number;
+	warnings: ParserWarning[];
+	failure?: ParserFailure;
+}
+
+export function createParserSuccess({
+	items,
+	candidateCount,
+	discardedCount,
+	minimumItems,
+	source,
+}: {
+	items: CrawlItemType[];
+	candidateCount: number;
+	discardedCount: number;
+	minimumItems: number;
+	source: string;
+}): ParserOutcome {
+	const warnings: ParserWarning[] = [];
+	if (discardedCount > 0) {
+		warnings.push({
+			code: "discarded-items",
+			message: `${source} 파서가 필수 조건을 충족하지 못한 항목을 제외했습니다.`,
+			count: discardedCount,
+		});
+	}
+	if (items.length < minimumItems) {
+		warnings.push({
+			code: "below-minimum-items",
+			message: `${source} 추출 건수가 최소 기준 ${minimumItems}건보다 적습니다.`,
+			count: items.length,
+		});
+	}
+
+	return {
+		status: "ok",
+		items,
+		candidateCount,
+		discardedCount,
+		warnings,
+	};
+}
+
+export function createParserEmpty(source: string): ParserOutcome {
+	return {
+		status: "empty",
+		items: [],
+		candidateCount: 0,
+		discardedCount: 0,
+		warnings: [
+			{
+				code: "empty-list",
+				message: `${source} 응답이 정상적인 빈 목록을 반환했습니다.`,
+				count: 0,
+			},
+		],
+	};
+}
+
+export function createParserFailure({
+	code,
+	message,
+	candidateCount = 0,
+	discardedCount = 0,
+}: {
+	code: ParserFailureCode;
+	message: string;
+	candidateCount?: number;
+	discardedCount?: number;
+}): ParserOutcome {
+	return {
+		status: "failure",
+		items: [],
+		candidateCount,
+		discardedCount,
+		warnings:
+			discardedCount > 0
+				? [
+						{
+							code: "discarded-items",
+							message: "파서가 모든 후보 항목을 제외했습니다.",
+							count: discardedCount,
+						},
+					]
+				: [],
+		failure: { code, message },
+	};
+}

--- a/app/api/crawl/route.test.ts
+++ b/app/api/crawl/route.test.ts
@@ -35,7 +35,15 @@ describe("POST /api/crawl", () => {
 			items: [{ url: "https://example.com/1", title: "one", host: "example.com" }],
 			attempted: 2,
 			succeeded: 1,
-			failures: [{ url: "https://example.com/2", message: "HTTP 500" }],
+			failures: [{ url: "https://example.com/2", message: "selector changed", kind: "parser" }],
+			warnings: [
+				{
+					url: "https://example.com/1",
+					code: "below-minimum-items",
+					message: "below minimum",
+					count: 1,
+				},
+			],
 		});
 	});
 
@@ -64,7 +72,26 @@ describe("POST /api/crawl", () => {
 		expect(response.status).toBe(200);
 		expect(body).toMatchObject({ target: "arcalive", attempted: 2, succeeded: 1 });
 		expect(body.failures).toHaveLength(1);
+		expect(body.warnings).toHaveLength(1);
 		expect(crawlerMocks.arcalive).toHaveBeenCalledTimes(1);
+	});
+
+	it("모든 요청이 parser failure이면 재시도 후 502를 반환한다", async () => {
+		vi.useFakeTimers();
+		crawlerMocks.arcalive.mockResolvedValue({
+			items: [],
+			attempted: 3,
+			succeeded: 0,
+			failures: [{ url: "https://example.com", message: "missing container", kind: "parser" }],
+			warnings: [],
+		});
+
+		const responsePromise = POST(createRequest("arcalive"));
+		await vi.runAllTimersAsync();
+		const response = await responsePromise;
+
+		expect(response.status).toBe(502);
+		expect(crawlerMocks.arcalive).toHaveBeenCalledTimes(2);
 	});
 
 	it("모든 요청이 timeout이면 재시도 후 504를 반환한다", async () => {
@@ -73,7 +100,15 @@ describe("POST /api/crawl", () => {
 			items: [],
 			attempted: 2,
 			succeeded: 0,
-			failures: [{ url: "https://example.com", message: "timed out", timeout: true }],
+			failures: [
+				{
+					url: "https://example.com",
+					message: "timed out",
+					kind: "network",
+					timeout: true,
+				},
+			],
+			warnings: [],
 		});
 
 		const responsePromise = POST(createRequest("arcalive"));
@@ -81,6 +116,36 @@ describe("POST /api/crawl", () => {
 		const response = await responsePromise;
 
 		expect(response.status).toBe(504);
+		expect(crawlerMocks.arcalive).toHaveBeenCalledTimes(2);
+	});
+
+	it("timeout과 parser failure가 섞이면 502를 반환한다", async () => {
+		vi.useFakeTimers();
+		crawlerMocks.arcalive.mockResolvedValue({
+			items: [],
+			attempted: 2,
+			succeeded: 0,
+			failures: [
+				{
+					url: "https://example.com/timeout",
+					message: "timed out",
+					kind: "network",
+					timeout: true,
+				},
+				{
+					url: "https://example.com/parser",
+					message: "missing container",
+					kind: "parser",
+				},
+			],
+			warnings: [],
+		});
+
+		const responsePromise = POST(createRequest("arcalive"));
+		await vi.runAllTimersAsync();
+		const response = await responsePromise;
+
+		expect(response.status).toBe(502);
 		expect(crawlerMocks.arcalive).toHaveBeenCalledTimes(2);
 	});
 });

--- a/app/api/crawl/route.ts
+++ b/app/api/crawl/route.ts
@@ -66,7 +66,10 @@ export async function POST(request: NextRequest) {
 		const durationMs = Date.now() - startTime;
 
 		if (!result || result.succeeded === 0) {
-			const status = result?.failures.some((failure) => failure.timeout) ? 504 : 502;
+			const allFailuresTimedOut =
+				(result?.failures.length ?? 0) > 0 &&
+				result?.failures.every((failure) => failure.timeout === true);
+			const status = allFailuresTimedOut ? 504 : 502;
 			return NextResponse.json(
 				{
 					error: "모든 소스 요청이 실패했습니다.",

--- a/app/api/crawl/source-adapters.test.ts
+++ b/app/api/crawl/source-adapters.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { crawlArcalive } from "./arcalive";
+import { crawlBattlepage } from "./battlepage";
+import { crawlInsagirl } from "./insagirl";
+
+const arcaliveFixture = readFileSync(
+	new URL("./fixtures/arcalive-current.html", import.meta.url),
+	"utf8"
+);
+const battlepageEmptyFixture = readFileSync(
+	new URL("./fixtures/battlepage-empty.html", import.meta.url),
+	"utf8"
+);
+const insagirlFixture = readFileSync(
+	new URL("./fixtures/insagirl-current.json", import.meta.url),
+	"utf8"
+);
+
+const htmlResponse = (body: string) =>
+	new Response(body, { status: 200, headers: { "Content-Type": "text/html" } });
+const jsonResponse = (body: string) =>
+	new Response(body, { status: 200, headers: { "Content-Type": "application/json" } });
+
+describe("crawler parser adapters", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("Arcalive의 성공·empty·parser failure를 페이지별로 구분한다", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(htmlResponse(arcaliveFixture))
+			.mockResolvedValueOnce(
+				htmlResponse(
+					'<div class="list-table table"><div class="list-empty">게시물이 없습니다.</div></div>'
+				)
+			)
+			.mockResolvedValueOnce(htmlResponse("<main>changed</main>"));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await crawlArcalive();
+
+		expect(result).toMatchObject({ attempted: 3, succeeded: 2 });
+		expect(result.items).toHaveLength(10);
+		expect(result.failures).toEqual([
+			expect.objectContaining({ kind: "parser", message: expect.stringContaining("container") }),
+		]);
+		expect(result.warnings.map((warning) => warning.code)).toEqual([
+			"discarded-items",
+			"empty-list",
+		]);
+	});
+
+	it("Battlepage의 정상 empty 응답은 성공과 warning으로 집계한다", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(htmlResponse(battlepageEmptyFixture)))
+		);
+
+		const result = await crawlBattlepage();
+
+		expect(result).toMatchObject({ attempted: 10, succeeded: 10, items: [], failures: [] });
+		expect(result.warnings).toHaveLength(10);
+		expect(result.warnings.every((warning) => warning.code === "empty-list")).toBe(true);
+	});
+
+	it("Insagirl 일부 parser failure가 다른 endpoint 결과를 폐기하지 않는다", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse(insagirlFixture))
+			.mockResolvedValueOnce(jsonResponse('{"items":[]}'));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await crawlInsagirl();
+
+		expect(result).toMatchObject({ attempted: 2, succeeded: 1 });
+		expect(result.items).toHaveLength(20);
+		expect(result.failures).toEqual([
+			expect.objectContaining({ kind: "parser", message: expect.stringContaining("v 배열") }),
+		]);
+		expect(result.warnings).toEqual([
+			expect.objectContaining({ code: "discarded-items", count: 1 }),
+		]);
+	});
+
+	it("Insagirl 손상 JSON을 network 오류가 아닌 parser failure로 분류한다", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse("{invalid"))
+			.mockResolvedValueOnce(jsonResponse(insagirlFixture));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await crawlInsagirl();
+
+		expect(result).toMatchObject({ attempted: 2, succeeded: 1 });
+		expect(result.failures).toEqual([
+			expect.objectContaining({ kind: "parser", message: expect.stringContaining("v 배열") }),
+		]);
+	});
+
+	it("HTTP·timeout 오류는 network failure로 유지한다", async () => {
+		const timeout = new Error("timed out");
+		timeout.name = "TimeoutError";
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(timeout));
+
+		const result = await crawlArcalive();
+
+		expect(result).toMatchObject({ attempted: 3, succeeded: 0, warnings: [] });
+		expect(result.failures).toHaveLength(3);
+		expect(result.failures[0]).toMatchObject({ kind: "network", timeout: true });
+	});
+});

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
 		"@radix-ui/react-navigation-menu": "^1.2.14",
 		"@radix-ui/react-slot": "^1.2.4",
 		"@radix-ui/react-toggle-group": "^1.1.10",
-		"@supabase/ssr": "0.9.0",
-		"@supabase/supabase-js": "^2.99.1",
+		"@supabase/ssr": "0.12.3",
+		"@supabase/supabase-js": "^2.110.7",
 		"@tanstack/react-query": "^5.90.21",
 		"autoprefixer": "10.4.27",
 		"cheerio": "^1.2.0",
@@ -40,9 +40,9 @@
 		"geist": "^1.7.0",
 		"linkifyjs": "^4.3.2",
 		"lucide-react": "^0.577.0",
-		"next": "16.1.6",
+		"next": "16.2.10",
 		"next-themes": "^0.4.6",
-		"postcss": "8.5.8",
+		"postcss": "8.5.20",
 		"react": "19.2.4",
 		"react-dom": "19.2.4",
 		"sonner": "^2.0.5",
@@ -60,21 +60,5 @@
 		"@types/react-dom": "19.2.3",
 		"cross-env": "^10.1.0",
 		"vitest": "^4.1.10"
-	},
-	"resolutions": {
-		"@radix-ui/react-dismissable-layer": "1.1.0",
-		"@radix-ui/react-focus-scope": "1.1.0"
-	},
-	"pnpm": {
-		"overrides": {
-			"ajv@^6": "6.14.0",
-			"flatted": "3.4.0",
-			"glob@^10": "10.5.0",
-			"js-yaml@^4": "4.1.1",
-			"minimatch@^3": "3.1.4",
-			"minimatch@^9": "9.0.7",
-			"undici@^6": "6.24.0",
-			"undici@^7": "7.24.3"
-		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,18 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@radix-ui/react-dismissable-layer': 1.1.0
-  '@radix-ui/react-focus-scope': 1.1.0
-  ajv@^6: 6.14.0
-  flatted: 3.4.0
-  glob@^10: 10.5.0
-  js-yaml@^4: 4.1.1
-  minimatch@^3: 3.1.4
-  minimatch@^9: 9.0.7
-  undici@^6: 6.24.0
-  undici@^7: 7.24.3
-
 importers:
 
   .:
@@ -36,17 +24,17 @@ importers:
         specifier: ^1.1.10
         version: 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@supabase/ssr':
-        specifier: 0.9.0
-        version: 0.9.0(@supabase/supabase-js@2.99.1)
+        specifier: 0.12.3
+        version: 0.12.3(@supabase/supabase-js@2.110.7)
       '@supabase/supabase-js':
-        specifier: ^2.99.1
-        version: 2.99.1
+        specifier: ^2.110.7
+        version: 2.110.7
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.4)
       autoprefixer:
         specifier: 10.4.27
-        version: 10.4.27(postcss@8.5.8)
+        version: 10.4.27(postcss@8.5.20)
       cheerio:
         specifier: ^1.2.0
         version: 1.2.0
@@ -61,7 +49,7 @@ importers:
         version: 4.1.0
       geist:
         specifier: ^1.7.0
-        version: 1.7.0(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 1.7.0(next@16.2.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       linkifyjs:
         specifier: ^4.3.2
         version: 4.3.2
@@ -69,14 +57,14 @@ importers:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)
       next:
-        specifier: 16.1.6
-        version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 16.2.10
+        version: 16.2.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postcss:
-        specifier: 8.5.8
-        version: 8.5.8
+        specifier: 8.5.20
+        version: 8.5.20
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -192,9 +180,6 @@ packages:
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
-
-  '@emnapi/runtime@1.8.1':
-    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -392,66 +377,63 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/env@16.1.6':
-    resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
+  '@next/env@16.2.10':
+    resolution: {integrity: sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==}
 
-  '@next/swc-darwin-arm64@16.1.6':
-    resolution: {integrity: sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==}
+  '@next/swc-darwin-arm64@16.2.10':
+    resolution: {integrity: sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.1.6':
-    resolution: {integrity: sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==}
+  '@next/swc-darwin-x64@16.2.10':
+    resolution: {integrity: sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.1.6':
-    resolution: {integrity: sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==}
+  '@next/swc-linux-arm64-gnu@16.2.10':
+    resolution: {integrity: sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.1.6':
-    resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
+  '@next/swc-linux-arm64-musl@16.2.10':
+    resolution: {integrity: sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.1.6':
-    resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
+  '@next/swc-linux-x64-gnu@16.2.10':
+    resolution: {integrity: sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.1.6':
-    resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
+  '@next/swc-linux-x64-musl@16.2.10':
+    resolution: {integrity: sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.1.6':
-    resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
+  '@next/swc-win32-arm64-msvc@16.2.10':
+    resolution: {integrity: sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.1.6':
-    resolution: {integrity: sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==}
+  '@next/swc-win32-x64-msvc@16.2.10':
+    resolution: {integrity: sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
-
-  '@radix-ui/primitive@1.1.0':
-    resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
 
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
@@ -496,15 +478,6 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-compose-refs@1.1.0':
-    resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
         optional: true
 
   '@radix-ui/react-compose-refs@1.1.2':
@@ -560,8 +533,21 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-dismissable-layer@1.1.0':
-    resolution: {integrity: sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==}
+  '@radix-ui/react-dismissable-layer@1.1.10':
+    resolution: {integrity: sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -604,8 +590,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-focus-scope@1.1.0':
-    resolution: {integrity: sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==}
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -704,19 +690,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-primitive@2.0.0':
-    resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
     peerDependencies:
@@ -754,15 +727,6 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-slot@1.1.0':
-    resolution: {integrity: sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
         optional: true
 
   '@radix-ui/react-slot@1.2.3':
@@ -809,15 +773,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-use-callback-ref@1.1.0':
-    resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
@@ -845,8 +800,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-use-escape-keydown@1.1.0':
-    resolution: {integrity: sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==}
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1007,34 +962,37 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@supabase/auth-js@2.99.1':
-    resolution: {integrity: sha512-x7lKKTvKjABJt/FYcRSPiTT01Xhm2FF8RhfL8+RHMkmlwmRQ88/lREupIHKwFPW0W6pTCJqkZb7Yhpw/EZ+fNw==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/auth-js@2.110.7':
+    resolution: {integrity: sha512-M5Bpl4hCv6kHcOO/xM06Dyfg1mYLHljMkp1plhzG9IRZPc3czvyMsSN1XpL5+GKisOKM3lSN59zhpcm6sMVXfA==}
+    engines: {node: '>=22.0.0'}
 
-  '@supabase/functions-js@2.99.1':
-    resolution: {integrity: sha512-WQE62W5geYImCO4jzFxCk/avnK7JmOdtqu2eiPz3zOaNiIJajNRSAwMMDgEGd2EMs+sUVYj1LfBjfmW3EzHgIA==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/functions-js@2.110.7':
+    resolution: {integrity: sha512-megYmexlYEoR/0qlsr4Snh9wtzAodO7MAri3NMevZrXzNvQRKlvmTcSBoKGLQEPDakgDZMqbMdf9DwoZz6qfoA==}
+    engines: {node: '>=22.0.0'}
 
-  '@supabase/postgrest-js@2.99.1':
-    resolution: {integrity: sha512-gtw2ibJrADvfqrpUWXGNlrYUvxttF4WVWfPpTFKOb2IRj7B6YRWMDgcrYqIuD4ZEabK4m6YKQCCGy6clgf1lPA==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/phoenix@0.4.5':
+    resolution: {integrity: sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==}
 
-  '@supabase/realtime-js@2.99.1':
-    resolution: {integrity: sha512-9EDdy/5wOseGFqxW88ShV9JMRhm7f+9JGY5x+LqT8c7R0X1CTLwg5qie8FiBWcXTZ+68yYxVWunI+7W4FhkWOg==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/postgrest-js@2.110.7':
+    resolution: {integrity: sha512-ban6YV0djhVaqVYezlOARKLIuOBSvLLhyQVZjA2nxPrtswhxHCl1+gI4giFgI9ATQAaMNbUZb4JXiuL5lEA/5g==}
+    engines: {node: '>=22.0.0'}
 
-  '@supabase/ssr@0.9.0':
-    resolution: {integrity: sha512-UFY6otYV3yqCgV+AyHj80vNkTvbf1Gas2LW4dpbQ4ap6p6v3eB2oaDfcI99jsuJzwVBCFU4BJI+oDYyhNk1z0Q==}
+  '@supabase/realtime-js@2.110.7':
+    resolution: {integrity: sha512-AMtZjyFA2gsmjuxopPNS/sRznLQHG0Ht5x+ytTPTOh3vAcOTUlVRLx7gW4/CONNnbb3PKOkE+HmM35HOSbmomQ==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/ssr@0.12.3':
+    resolution: {integrity: sha512-qWXJ/dI7CiYDKyTgIPqJ4Qkh8y5edh2LdF/nkN48z47mmEVzAO2OE+YErYeQ/UemVfonn/F4kFz+lhLqoVMdpw==}
     peerDependencies:
-      '@supabase/supabase-js': ^2.97.0
+      '@supabase/supabase-js': ^2.110.5
 
-  '@supabase/storage-js@2.99.1':
-    resolution: {integrity: sha512-mf7zPfqofI62SOoyQJeNUVxe72E4rQsbWim6lTDPeLu3lHija/cP5utlQADGrjeTgOUN6znx/rWn7SjrETP1dw==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/storage-js@2.110.7':
+    resolution: {integrity: sha512-2tcDE8cjEDy1uKxKavBpKQod1JdMV1jDXQag48TCa+kycmJOltc0yVabC0BUlhOwAl6WykXU2aOsH3ELMtZrmQ==}
+    engines: {node: '>=22.0.0'}
 
-  '@supabase/supabase-js@2.99.1':
-    resolution: {integrity: sha512-5MRoYD9ffXq8F6a036dm65YoSHisC3by/d22mauKE99Vrwf792KxYIIr/iqCX7E4hkuugbPZ5EGYHTB7MKy6Vg==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/supabase-js@2.110.7':
+    resolution: {integrity: sha512-AnfO3A230Shy6RMO7cya3Wl1OcXnABJrzH8vP+fY7/RFjhzcchB7DjKkkTIAntlwekD+GkSFzEvt2tC+D4Fp8w==}
+    engines: {node: '>=22.0.0'}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1154,9 +1112,6 @@ packages:
   '@types/node@20.11.5':
     resolution: {integrity: sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==}
 
-  '@types/phoenix@1.6.7':
-    resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
-
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1164,9 +1119,6 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
-
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
@@ -1387,8 +1339,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
@@ -1399,8 +1351,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -1411,8 +1363,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
@@ -1423,8 +1375,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -1435,8 +1387,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
@@ -1448,8 +1400,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -1462,8 +1414,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -1476,8 +1428,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -1490,8 +1442,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -1503,8 +1455,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -1515,8 +1467,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
@@ -1525,8 +1477,8 @@ packages:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
 
-  lightningcss@1.32.0:
-    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   linkifyjs@4.3.2:
@@ -1540,11 +1492,6 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1556,8 +1503,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.1.6:
-    resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
+  next@16.2.10:
+    resolution: {integrity: sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -1606,8 +1553,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   picomatch@4.0.5:
@@ -1623,10 +1570,6 @@ packages:
 
   postcss@8.5.20:
     resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   react-dom@19.2.4:
@@ -1783,8 +1726,8 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici@7.24.3:
-    resolution: {integrity: sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   update-browserslist-db@1.2.3:
@@ -1922,18 +1865,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -1980,11 +1911,6 @@ snapshots:
     optional: true
 
   '@emnapi/runtime@1.11.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2098,7 +2024,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/runtime': 1.11.1
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -2136,35 +2062,33 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@next/env@16.1.6': {}
+  '@next/env@16.2.10': {}
 
-  '@next/swc-darwin-arm64@16.1.6':
+  '@next/swc-darwin-arm64@16.2.10':
     optional: true
 
-  '@next/swc-darwin-x64@16.1.6':
+  '@next/swc-darwin-x64@16.2.10':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.1.6':
+  '@next/swc-linux-arm64-gnu@16.2.10':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.1.6':
+  '@next/swc-linux-arm64-musl@16.2.10':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.1.6':
+  '@next/swc-linux-x64-gnu@16.2.10':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.1.6':
+  '@next/swc-linux-x64-musl@16.2.10':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.1.6':
+  '@next/swc-win32-arm64-msvc@16.2.10':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.1.6':
+  '@next/swc-win32-x64-msvc@16.2.10':
     optional: true
 
   '@oxc-project/types@0.139.0': {}
-
-  '@radix-ui/primitive@1.1.0': {}
 
   '@radix-ui/primitive@1.1.2': {}
 
@@ -2205,12 +2129,6 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-compose-refs@1.1.0(@types/react@19.2.14)(react@19.2.4)':
-    dependencies:
-      react: 19.2.4
-    optionalDependencies:
-      '@types/react': 19.2.14
-
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -2228,9 +2146,9 @@ snapshots:
       '@radix-ui/primitive': 1.1.2
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2250,9 +2168,9 @@ snapshots:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2273,13 +2191,26 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-dismissable-layer@1.1.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-dismissable-layer@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/primitive': 1.1.0
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -2313,11 +2244,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-focus-scope@1.1.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -2338,9 +2269,9 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2364,7 +2295,7 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2427,15 +2358,6 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-primitive@2.0.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@radix-ui/react-slot': 1.1.0(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
@@ -2479,13 +2401,6 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-slot@1.1.0(@types/react@19.2.14)(react@19.2.4)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
-    optionalDependencies:
-      '@types/react': 19.2.14
-
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
@@ -2526,12 +2441,6 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-use-callback-ref@1.1.0(@types/react@19.2.14)(react@19.2.4)':
-    dependencies:
-      react: 19.2.4
-    optionalDependencies:
-      '@types/react': 19.2.14
-
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -2553,9 +2462,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-escape-keydown@1.1.0(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -2650,48 +2559,42 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@supabase/auth-js@2.99.1':
+  '@supabase/auth-js@2.110.7':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/functions-js@2.99.1':
+  '@supabase/functions-js@2.110.7':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/postgrest-js@2.99.1':
+  '@supabase/phoenix@0.4.5': {}
+
+  '@supabase/postgrest-js@2.110.7':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/realtime-js@2.99.1':
+  '@supabase/realtime-js@2.110.7':
     dependencies:
-      '@types/phoenix': 1.6.7
-      '@types/ws': 8.18.1
+      '@supabase/phoenix': 0.4.5
       tslib: 2.8.1
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
-  '@supabase/ssr@0.9.0(@supabase/supabase-js@2.99.1)':
+  '@supabase/ssr@0.12.3(@supabase/supabase-js@2.110.7)':
     dependencies:
-      '@supabase/supabase-js': 2.99.1
+      '@supabase/supabase-js': 2.110.7
       cookie: 1.0.2
 
-  '@supabase/storage-js@2.99.1':
+  '@supabase/storage-js@2.110.7':
     dependencies:
       iceberg-js: 0.8.1
       tslib: 2.8.1
 
-  '@supabase/supabase-js@2.99.1':
+  '@supabase/supabase-js@2.110.7':
     dependencies:
-      '@supabase/auth-js': 2.99.1
-      '@supabase/functions-js': 2.99.1
-      '@supabase/postgrest-js': 2.99.1
-      '@supabase/realtime-js': 2.99.1
-      '@supabase/storage-js': 2.99.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
+      '@supabase/auth-js': 2.110.7
+      '@supabase/functions-js': 2.110.7
+      '@supabase/postgrest-js': 2.110.7
+      '@supabase/realtime-js': 2.110.7
+      '@supabase/storage-js': 2.110.7
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2763,7 +2666,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
-      postcss: 8.5.8
+      postcss: 8.5.20
       tailwindcss: 4.2.1
 
   '@tanstack/query-core@5.90.20': {}
@@ -2791,8 +2694,6 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/phoenix@1.6.7': {}
-
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -2800,10 +2701,6 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
-
-  '@types/ws@8.18.1':
-    dependencies:
-      '@types/node': 20.11.5
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -2852,13 +2749,13 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  autoprefixer@10.4.27(postcss@8.5.8):
+  autoprefixer@10.4.27(postcss@8.5.20):
     dependencies:
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001777
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.8
+      postcss: 8.5.20
       postcss-value-parser: 4.2.0
 
   baseline-browser-mapping@2.10.0: {}
@@ -2897,7 +2794,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.24.3
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   class-variance-authority@0.7.1:
@@ -2987,9 +2884,9 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -3000,9 +2897,9 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  geist@1.7.0(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  geist@1.7.0(next@16.2.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
-      next: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   get-nonce@1.0.1: {}
 
@@ -3028,67 +2925,67 @@ snapshots:
   lightningcss-android-arm64@1.31.1:
     optional: true
 
-  lightningcss-android-arm64@1.32.0:
+  lightningcss-android-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-arm64@1.31.1:
     optional: true
 
-  lightningcss-darwin-arm64@1.32.0:
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.31.1:
     optional: true
 
-  lightningcss-darwin-x64@1.32.0:
+  lightningcss-darwin-x64@1.33.0:
     optional: true
 
   lightningcss-freebsd-x64@1.31.1:
     optional: true
 
-  lightningcss-freebsd-x64@1.32.0:
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.31.1:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
+  lightningcss-linux-arm-gnueabihf@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.31.1:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.32.0:
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.31.1:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.32.0:
+  lightningcss-linux-arm64-musl@1.33.0:
     optional: true
 
   lightningcss-linux-x64-gnu@1.31.1:
     optional: true
 
-  lightningcss-linux-x64-gnu@1.32.0:
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.31.1:
     optional: true
 
-  lightningcss-linux-x64-musl@1.32.0:
+  lightningcss-linux-x64-musl@1.33.0:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.31.1:
     optional: true
 
-  lightningcss-win32-arm64-msvc@1.32.0:
+  lightningcss-win32-arm64-msvc@1.33.0:
     optional: true
 
   lightningcss-win32-x64-msvc@1.31.1:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.32.0:
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
   lightningcss@1.31.1:
@@ -3107,21 +3004,21 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
 
-  lightningcss@1.32.0:
+  lightningcss@1.33.0:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
-      lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
-      lightningcss-linux-arm64-gnu: 1.32.0
-      lightningcss-linux-arm64-musl: 1.32.0
-      lightningcss-linux-x64-gnu: 1.32.0
-      lightningcss-linux-x64-musl: 1.32.0
-      lightningcss-win32-arm64-msvc: 1.32.0
-      lightningcss-win32-x64-msvc: 1.32.0
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   linkifyjs@4.3.2: {}
 
@@ -3133,8 +3030,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  nanoid@3.3.11: {}
-
   nanoid@3.3.16: {}
 
   next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -3142,9 +3037,9 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@next/env': 16.1.6
+      '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.0
       caniuse-lite: 1.0.30001777
@@ -3153,14 +3048,14 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(react@19.2.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.6
-      '@next/swc-darwin-x64': 16.1.6
-      '@next/swc-linux-arm64-gnu': 16.1.6
-      '@next/swc-linux-arm64-musl': 16.1.6
-      '@next/swc-linux-x64-gnu': 16.1.6
-      '@next/swc-linux-x64-musl': 16.1.6
-      '@next/swc-win32-arm64-msvc': 16.1.6
-      '@next/swc-win32-x64-msvc': 16.1.6
+      '@next/swc-darwin-arm64': 16.2.10
+      '@next/swc-darwin-x64': 16.2.10
+      '@next/swc-linux-arm64-gnu': 16.2.10
+      '@next/swc-linux-arm64-musl': 16.2.10
+      '@next/swc-linux-x64-gnu': 16.2.10
+      '@next/swc-linux-x64-musl': 16.2.10
+      '@next/swc-win32-arm64-msvc': 16.2.10
+      '@next/swc-win32-x64-msvc': 16.2.10
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -3193,7 +3088,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   picomatch@4.0.5: {}
 
@@ -3201,19 +3096,13 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.20:
     dependencies:
       nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.8:
-    dependencies:
-      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3362,8 +3251,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:
@@ -3378,7 +3267,7 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici@7.24.3: {}
+  undici@7.28.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -3412,7 +3301,7 @@ snapshots:
 
   vite@8.1.5(@types/node@20.11.5)(jiti@2.6.1):
     dependencies:
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       picomatch: 4.0.5
       postcss: 8.5.20
       rolldown: 1.1.5
@@ -3436,7 +3325,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.4
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
@@ -3463,5 +3352,3 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  ws@8.19.0: {}

--- a/supabase/functions/crawl-source/helpers-test.ts
+++ b/supabase/functions/crawl-source/helpers-test.ts
@@ -3,6 +3,7 @@
 import {
 	chunkUrlsForHistoryQuery,
 	constantTimeEquals,
+	countCrawlWarnings,
 	dedupeByUrl,
 	defineType,
 	hasMinimumInternalSecretLength,
@@ -58,6 +59,10 @@ Deno.test("URL deduplication keeps the first item", () => {
 
 	assert(result.length === 2, "duplicate URL should be removed");
 	assert(result[0].title === "first", "first item should win");
+});
+
+Deno.test("crawl warning count includes partial failures and parser warnings", () => {
+	assert(countCrawlWarnings([{}], [{}, {}]) === 3, "all warning conditions should be counted");
 });
 
 Deno.test("history query chunks limit both item count and encoded URL length", () => {

--- a/supabase/functions/crawl-source/helpers.ts
+++ b/supabase/functions/crawl-source/helpers.ts
@@ -53,6 +53,10 @@ export function dedupeByUrl<T extends { url: string }>(items: T[]) {
 	return Array.from(deduped.values());
 }
 
+export function countCrawlWarnings(failures: unknown[], warnings: unknown[]) {
+	return failures.length + warnings.length;
+}
+
 export function chunkUrlsForHistoryQuery(
 	urls: string[],
 	maxItems = 200,

--- a/supabase/functions/crawl-source/index.ts
+++ b/supabase/functions/crawl-source/index.ts
@@ -6,6 +6,7 @@ import {
 	type CrawlTarget,
 	chunkUrlsForHistoryQuery,
 	constantTimeEquals,
+	countCrawlWarnings,
 	dedupeByUrl,
 	defineType,
 	type FilterKeyword,
@@ -31,6 +32,14 @@ interface CrawlItem {
 interface CrawlFailure {
 	url: string;
 	message: string;
+	kind: "network" | "parser";
+}
+
+interface CrawlWarning {
+	url: string;
+	code: "empty-list" | "below-minimum-items" | "discarded-items";
+	message: string;
+	count: number;
 }
 
 interface CrawlApiResponse {
@@ -39,6 +48,7 @@ interface CrawlApiResponse {
 	attempted: number;
 	succeeded: number;
 	failures: CrawlFailure[];
+	warnings: CrawlWarning[];
 	durationMs: number;
 }
 
@@ -210,7 +220,10 @@ async function processCrawl(context: CrawlRequestContext, startedAt: number) {
 		target: context.target,
 		insertedCount: Number(counts.insertedCount ?? 0),
 		skippedCount: prepared.existingCount + Number(counts.skippedCount ?? 0),
-		warningCount: Array.isArray(crawlData.failures) ? crawlData.failures.length : 0,
+		warningCount: countCrawlWarnings(
+			Array.isArray(crawlData.failures) ? crawlData.failures : [],
+			Array.isArray(crawlData.warnings) ? crawlData.warnings : []
+		),
 		durationMs: Date.now() - startedAt,
 	});
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
 		"noEmit": true,
 		"esModuleInterop": true,
 		"module": "esnext",
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"resolveJsonModule": true,
 		"isolatedModules": true,
 		"jsx": "react-jsx",


### PR DESCRIPTION
## 변경 사항
- P1-4 크롤러 파서를 순수 함수와 fixture 기반 테스트로 분리했습니다.
- Next 16.2.10, Supabase 2.110.7/SSR 0.12.3, PostCSS 8.5.20으로 보안 패치했습니다.
- 오래된 pnpm overrides와 Radix resolutions를 제거했습니다.
- undici 7.28.0 이상을 사용하고 취약한 ws 의존성을 제거했습니다.

## 검증
- pnpm audit --audit-level high
- pnpm run ci
- git diff --check