### PR TITLE
P1-5 보안 경고 차단 프로세스 완성

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Evaluate repository security alerts
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SECURITY_ALERTS_TOKEN }}
         run: >-
           pnpm security:gate --
           --baseline security/alert-baseline.json

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -1,0 +1,63 @@
+name: Security Gate
+
+on:
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: read
+
+concurrency:
+  group: security-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  security-gate:
+    name: security-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Audit high and critical dependencies
+        run: pnpm audit --audit-level high
+
+      - name: Validate package overrides
+        run: pnpm security:overrides
+
+      - name: Evaluate repository security alerts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          pnpm security:gate --
+          --baseline security/alert-baseline.json
+          --out reports/security/security-gate-result.json
+
+      - name: Upload security gate result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-gate-result
+          path: reports/security/security-gate-result.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ erDiagram
 - 기준 문서: `SECURITY.md`
 - 로컬 보안 점검:
   - `pnpm security:collect-alerts`
+  - `pnpm security:baseline`
   - `pnpm security:gate`
+  - `pnpm security:overrides`
 - CI에서는 CodeQL + Dependabot 흐름으로 지속 점검
 
 ### 5) 코드 컨벤션

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,28 +1,38 @@
-# Security Policy
+# 보안 정책
 
-## Supported Branch
+## 지원 브랜치
 
-- `master`
+- 운영 및 보안 지원 기준 브랜치는 `master`입니다.
+- `master` 대상 PR은 `CI`, `CodeQL`, `Security Gate`를 통과해야 합니다.
 
-## Vulnerability Intake
+## 취약점 접수
 
-- Primary channel: GitHub Security Advisories / Defendbot alerts.
-- Optional disclosure path: open a private security advisory on this repository.
+- 의존성 취약점은 GitHub Dependabot Alerts로 관리합니다.
+- 코드 취약점은 CodeQL, secret 노출은 GitGuardian 결과를 기준으로 확인합니다.
+- 비공개 제보가 필요하면 GitHub의 private security advisory를 사용합니다.
 
-## Triage and SLA
+## 차단 정책과 처리 기한
 
-- `high` (and above): remediation or documented mitigation within **72 hours**.
-- `medium`: remediation or documented mitigation within **14 days**.
-- `low` / `unknown`: backlog triage with risk acceptance decision recorded.
+- `critical`·`high`: 허용 기준선 없이 0건을 유지하며, 발견 즉시 PR과 Security Gate를 차단합니다.
+- 수집 API 오류: 실제 상태를 확인할 수 없으므로 fail-closed로 차단합니다.
+- `medium`: 병합을 차단하지 않지만 14일 안에 수정하거나 위험 수용 근거를 기록합니다.
+- `low`·`unknown`: 정기 보안 검토에서 처리 우선순위를 결정합니다.
+- 비활성화된 scanner는 실패가 아닌 운영 경고로 보고합니다.
 
-## Alert Handling Rules
+## 기준선과 package override
 
-- Open alerts are reviewed in regular security triage and remediated by SLA.
-- Disabled scanners (for example, code scanning or secret scanning not enabled) are recorded as `disabled` and tracked separately from failing conditions.
+- `security/alert-baseline.json`은 high/critical이 0건일 때만 생성할 수 있습니다.
+- 기준선은 자동 갱신하지 않으며 PR에서 변경 내용을 검토합니다.
+- `pnpm.overrides`나 `resolutions`를 추가할 때는 `security/package-overrides.json`에 사유와 제거 조건을 등록해야 합니다.
+- override는 최대 90일마다 재검토하며 기한이 지나면 Security Gate가 실패합니다.
 
-## Verification
+## 검증 명령
 
-- Security status is validated in CI by:
-  - Dependabot updates (`.github/dependabot.yml`)
-  - CodeQL workflow (`.github/workflows/codeql.yml`)
-- Optional local/ops check: `pnpm security:collect-alerts` and `pnpm security:gate`.
+```powershell
+pnpm audit --audit-level high
+pnpm security:overrides
+pnpm security:gate
+pnpm run ci
+```
+
+세부 운영 절차와 GitGuardian 판정 원칙은 `docs/SECURITY_OPERATIONS.md`를 따릅니다.

--- a/docs/SECURITY_OPERATIONS.md
+++ b/docs/SECURITY_OPERATIONS.md
@@ -31,6 +31,8 @@ false positive 처리 기록에는 detector, 파일과 줄, commit, 인증에 �
 
 ## 3. 기준선 갱신
 
+GitHub Actions의 live alert 수집에는 저장소 Actions secret `SECURITY_ALERTS_TOKEN`을 사용합니다. 이 값은 Applemint 저장소만 접근하는 fine-grained PAT로 만들고 Dependabot alerts, Code scanning alerts, Secret scanning alerts의 읽기 권한만 부여합니다. 만료 전에 새 토큰으로 교체하며 workflow나 로그에 값을 출력하지 않습니다.
+
 ```powershell
 pnpm security:collect-alerts
 pnpm security:baseline

--- a/docs/SECURITY_OPERATIONS.md
+++ b/docs/SECURITY_OPERATIONS.md
@@ -1,0 +1,54 @@
+# 보안 경고 운영 절차
+
+## 1. Dependabot·CodeQL 처리
+
+1. `critical`·`high` 경고는 배포와 병합을 중단하고 패치 버전과 영향 경로를 확인합니다.
+2. 직접 의존성을 우선 갱신하고, 전이 의존성 override는 상위 패키지 갱신이 불가능할 때만 사용합니다.
+3. `pnpm why <package>`와 `pnpm audit --audit-level high`로 취약 경로가 사라졌는지 확인합니다.
+4. 전체 CI와 운영 smoke test가 통과한 후 master에 반영합니다.
+5. GitHub alert가 종료된 것을 확인한 뒤 중복 Dependabot PR을 superseded로 닫습니다.
+
+medium 경고는 14일 안에 수정하거나, 기준선 PR에 영향 범위와 위험 수용 근거를 남깁니다. 기준선은 경고를 숨기지 않으며 신규·해결 경고를 비교하기 위한 기록입니다.
+
+## 2. GitGuardian 판정 원칙
+
+다음 값은 실제 사용 여부가 불확실해도 먼저 true positive로 취급합니다.
+
+- Supabase service role key, anon key, JWT signing secret
+- `CRAWL_INTERNAL_SECRET`, API key, OAuth client secret
+- 운영 DB 비밀번호나 실제 로그인 비밀번호
+- 외부 서비스에서 인증 수단으로 사용할 수 있는 고엔트로피 문자열
+
+실제 secret이면 노출 범위를 확인한 뒤 새 값 발급, 환경변수 교체, 재배포, 기존 값 폐기 순서로 회전합니다. 이후 Supabase·Vercel·GitHub·외부 서비스 로그를 확인하고 incident를 해결합니다. 파일에서 문자열만 삭제한 것으로 처리를 끝내지 않습니다.
+
+다음 값은 인증 수단이 아님을 확인한 경우에만 false positive로 처리할 수 있습니다.
+
+- migration과 RLS 테스트에 고정된 Supabase Auth 사용자 UUID
+- `127.0.0.1` 또는 local Supabase에만 연결되는 명백한 테스트 비밀번호
+- 공개 문서에 이미 노출된 식별자나 재현용 placeholder
+
+false positive 처리 기록에는 detector, 파일과 줄, commit, 인증에 사용할 수 없는 이유, 확인자, 처리일을 남깁니다. GitGuardian Dashboard에서 개별 incident 또는 정확한 fingerprint만 제외하며 migration 전체, test 폴더 전체, detector 전체를 허용 목록에 넣지 않습니다.
+
+## 3. 기준선 갱신
+
+```powershell
+pnpm security:collect-alerts
+pnpm security:baseline
+git diff -- security/alert-baseline.json
+pnpm security:gate
+```
+
+- `security:baseline`이 high/critical 때문에 실패하면 예외를 추가하지 않고 취약점을 먼저 수정합니다.
+- resolved alert 삭제와 신규 medium/low 추가를 PR diff에서 각각 확인합니다.
+- scanner 수집 오류나 권한 오류 상태에서는 기준선을 갱신하지 않습니다.
+
+## 4. Package override 검토
+
+override가 꼭 필요한 경우 `security/package-overrides.json`에 다음을 기록합니다.
+
+- manager와 selector, 강제 버전
+- 도입 이유와 도입일
+- 마지막 검토일과 90일 이내의 다음 검토일
+- 상위 패키지 갱신 등 구체적인 제거 조건
+
+검토 시 override를 제거한 상태로 lockfile을 다시 계산하고 audit와 전체 CI를 실행합니다. 안전 버전이 자연스럽게 선택되면 override와 등록 내역을 함께 삭제합니다.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
 		"typecheck": "tsc --noEmit --incremental false",
 		"check:edge": "deno check --config supabase/functions/deno.json --lock deno.lock --frozen supabase/functions/crawl-source/index.ts",
 		"security:collect-alerts": "node scripts/security/collect-alerts.mjs",
-		"security:gate": "node scripts/security/security-gate.mjs"
+		"security:baseline": "node scripts/security/create-baseline.mjs",
+		"security:gate": "node scripts/security/security-gate.mjs",
+		"security:overrides": "node scripts/security/check-overrides.mjs"
 	},
 	"dependencies": {
 		"@radix-ui/react-alert-dialog": "^1.1.15",

--- a/scripts/security/check-overrides.mjs
+++ b/scripts/security/check-overrides.mjs
@@ -1,0 +1,28 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { validateOverrideRegistry } from "./override-policy.mjs";
+
+async function readJson(path) {
+	return JSON.parse(await readFile(resolve(path), "utf8"));
+}
+
+async function main() {
+	const packageJson = await readJson("package.json");
+	const registry = await readJson("security/package-overrides.json");
+	const result = validateOverrideRegistry(packageJson, registry);
+
+	if (!result.valid) {
+		for (const error of result.errors) {
+			console.error(`::error::${error}`);
+		}
+		process.exitCode = 1;
+		return;
+	}
+
+	console.log(`Package override registry is valid. Overrides: ${result.overrideCount}`);
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/scripts/security/collect-alerts.mjs
+++ b/scripts/security/collect-alerts.mjs
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import {
 	countBySeverity,
-	dedupeByAlertNumber,
+	dedupeAlertsByKey,
 	detectRepository,
 	detectToken,
 	fetchAndNormalizeAlerts,
@@ -33,7 +33,7 @@ async function main() {
 	const token = detectToken();
 
 	const snapshot = await fetchAndNormalizeAlerts({ repo, token });
-	const uniqueAlerts = dedupeByAlertNumber(snapshot.normalized_alerts).alerts;
+	const uniqueAlerts = dedupeAlertsByKey(snapshot.normalized_alerts).alerts;
 	const severity = countBySeverity(uniqueAlerts);
 	const outputPath = resolve(args.out);
 
@@ -43,7 +43,7 @@ async function main() {
 	console.log(`Repository: ${repo}`);
 	console.log(`Output: ${outputPath}`);
 	console.log(`Raw alerts: ${snapshot.dedup.alert_count_raw}`);
-	console.log(`Unique alerts (number): ${snapshot.dedup.alert_count_unique_by_number}`);
+	console.log(`Unique alerts (stable key): ${snapshot.dedup.alert_count_unique_by_key}`);
 	console.log(
 		`Unique advisories (ghsa+package): ${snapshot.dedup.advisory_count_unique_ghsa_package}`
 	);

--- a/scripts/security/create-baseline.mjs
+++ b/scripts/security/create-baseline.mjs
@@ -1,0 +1,39 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { detectRepository, detectToken, fetchAndNormalizeAlerts } from "./github-alerts.mjs";
+import { createAlertBaseline } from "./security-policy.mjs";
+
+function parseArgs(argv) {
+	const args = { repo: null, out: "security/alert-baseline.json" };
+	for (let index = 0; index < argv.length; index += 1) {
+		if (argv[index] === "--repo") {
+			args.repo = argv[index + 1] ?? null;
+			index += 1;
+		} else if (argv[index] === "--out") {
+			args.out = argv[index + 1] ?? args.out;
+			index += 1;
+		}
+	}
+	return args;
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const repository = detectRepository(args.repo);
+	const snapshot = await fetchAndNormalizeAlerts({
+		repo: repository,
+		token: detectToken(),
+	});
+	const baseline = createAlertBaseline(snapshot.normalized_alerts);
+	const outputPath = resolve(args.out);
+
+	await mkdir(dirname(outputPath), { recursive: true });
+	await writeFile(outputPath, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
+	console.log(`Security alert baseline written: ${outputPath}`);
+	console.log(`Baseline alerts: ${baseline.alerts.length}`);
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/scripts/security/github-alerts.mjs
+++ b/scripts/security/github-alerts.mjs
@@ -240,11 +240,16 @@ export async function fetchAndNormalizeAlerts({ repo, token }) {
 		};
 
 		if (result.status === "ok") {
-			normalized.push(...result.alerts.map((alert) => SOURCE_CONFIG[source].normalize(alert)));
+			normalized.push(
+				...result.alerts.map((alert) => {
+					const normalizedAlert = SOURCE_CONFIG[source].normalize(alert);
+					return { ...normalizedAlert, key: getAlertKey(normalizedAlert) };
+				})
+			);
 		}
 	}
 
-	const dedupedByNumber = dedupeByAlertNumber(normalized);
+	const dedupedByKey = dedupeAlertsByKey(normalized);
 	const dedupedAdvisories = dedupeByAdvisory(normalized);
 
 	return {
@@ -254,32 +259,45 @@ export async function fetchAndNormalizeAlerts({ repo, token }) {
 		normalized_alerts: normalized,
 		dedup: {
 			alert_count_raw: normalized.length,
-			alert_count_unique_by_number: dedupedByNumber.alerts.length,
-			alert_duplicate_numbers: dedupedByNumber.duplicate_numbers,
+			alert_count_unique_by_key: dedupedByKey.alerts.length,
+			alert_duplicate_keys: dedupedByKey.duplicate_keys,
 			advisory_count_unique_ghsa_package: dedupedAdvisories.length,
 			advisories_unique_ghsa_package: dedupedAdvisories,
 		},
 	};
 }
 
-export function dedupeByAlertNumber(alerts) {
+export function getAlertKey(alert) {
+	if (alert.source === "dependabot" && alert.ghsa && alert.package) {
+		return `dependabot:${alert.ghsa}:${alert.package}`;
+	}
+
+	if (alert.source && alert.alert_number !== null && alert.alert_number !== undefined) {
+		return `${alert.source}:${alert.alert_number}`;
+	}
+
+	throw new Error("Cannot create a stable key for a security alert.");
+}
+
+export function dedupeAlertsByKey(alerts) {
 	const seen = new Set();
-	const duplicateNumbers = new Set();
+	const duplicateKeys = new Set();
 	const uniqueAlerts = [];
 
 	for (const alert of alerts) {
-		const key = String(alert.alert_number);
+		const key = alert.key ?? getAlertKey(alert);
 		if (seen.has(key)) {
-			duplicateNumbers.add(alert.alert_number);
+			duplicateKeys.add(key);
 			continue;
 		}
+
 		seen.add(key);
-		uniqueAlerts.push(alert);
+		uniqueAlerts.push({ ...alert, key });
 	}
 
 	return {
 		alerts: uniqueAlerts,
-		duplicate_numbers: [...duplicateNumbers].sort((a, b) => Number(a) - Number(b)),
+		duplicate_keys: [...duplicateKeys].sort(),
 	};
 }
 

--- a/scripts/security/github-alerts.test.ts
+++ b/scripts/security/github-alerts.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { dedupeAlertsByKey, getAlertKey } from "./github-alerts.mjs";
+
+describe("security alert stable keys", () => {
+	it("Dependabot의 동일 GHSA·package manifest 중복을 하나로 집계한다", () => {
+		const alerts = [
+			{
+				alert_number: 10,
+				ghsa: "GHSA-test-0001",
+				package: "example-package",
+				source: "dependabot",
+			},
+			{
+				alert_number: 11,
+				ghsa: "GHSA-test-0001",
+				package: "example-package",
+				source: "dependabot",
+			},
+		];
+
+		const result = dedupeAlertsByKey(alerts);
+
+		expect(result.alerts).toHaveLength(1);
+		expect(result.alerts[0].key).toBe("dependabot:GHSA-test-0001:example-package");
+		expect(result.duplicate_keys).toEqual(["dependabot:GHSA-test-0001:example-package"]);
+	});
+
+	it("서로 다른 scanner의 동일 alert number를 충돌시키지 않는다", () => {
+		const alerts = [
+			{ alert_number: 1, source: "code_scanning" },
+			{ alert_number: 1, source: "secret_scanning" },
+		];
+
+		expect(alerts.map(getAlertKey)).toEqual(["code_scanning:1", "secret_scanning:1"]);
+		expect(dedupeAlertsByKey(alerts).alerts).toHaveLength(2);
+	});
+});

--- a/scripts/security/override-policy.mjs
+++ b/scripts/security/override-policy.mjs
@@ -1,0 +1,124 @@
+export const OVERRIDE_REGISTRY_SCHEMA_VERSION = 1;
+export const MAX_OVERRIDE_REVIEW_DAYS = 90;
+
+const REQUIRED_TEXT_FIELDS = [
+	"reason",
+	"introducedAt",
+	"lastReviewedAt",
+	"nextReviewAt",
+	"removalCriteria",
+];
+
+function entryKey(manager, selector) {
+	return `${manager}:${selector}`;
+}
+
+function collectObjectEntries(manager, value) {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return [];
+	}
+
+	return Object.entries(value).map(([selector, version]) => ({
+		manager,
+		selector,
+		version: String(version),
+	}));
+}
+
+export function collectPackageOverrides(packageJson) {
+	return [
+		...collectObjectEntries("pnpm.overrides", packageJson?.pnpm?.overrides),
+		...collectObjectEntries("resolutions", packageJson?.resolutions),
+	].sort((left, right) =>
+		entryKey(left.manager, left.selector).localeCompare(entryKey(right.manager, right.selector))
+	);
+}
+
+function parseDate(value, field, key, errors) {
+	const timestamp = Date.parse(value);
+	if (!Number.isFinite(timestamp)) {
+		errors.push(`${key}: ${field} must be a valid ISO date.`);
+		return null;
+	}
+	return timestamp;
+}
+
+function validateReviewDates(entry, key, now, errors) {
+	const introducedAt = parseDate(entry.introducedAt, "introducedAt", key, errors);
+	const lastReviewedAt = parseDate(entry.lastReviewedAt, "lastReviewedAt", key, errors);
+	const nextReviewAt = parseDate(entry.nextReviewAt, "nextReviewAt", key, errors);
+	if (introducedAt !== null && lastReviewedAt !== null && lastReviewedAt < introducedAt) {
+		errors.push(`${key}: lastReviewedAt cannot be before introducedAt.`);
+	}
+	if (lastReviewedAt === null || nextReviewAt === null) {
+		return;
+	}
+
+	const reviewWindowDays = (nextReviewAt - lastReviewedAt) / 86_400_000;
+	if (reviewWindowDays <= 0 || reviewWindowDays > MAX_OVERRIDE_REVIEW_DAYS) {
+		errors.push(`${key}: next review must be within ${MAX_OVERRIDE_REVIEW_DAYS} days.`);
+	}
+	if (now.getTime() > nextReviewAt) {
+		errors.push(`${key}: override review is overdue.`);
+	}
+}
+
+function validateRegistryEntry(entry, overrideByKey, registryByKey, now, errors) {
+	const key = entryKey(entry.manager, entry.selector);
+	if (registryByKey.has(key)) {
+		errors.push(`${key}: duplicate registry entry.`);
+		return;
+	}
+	registryByKey.set(key, entry);
+
+	for (const field of REQUIRED_TEXT_FIELDS) {
+		if (typeof entry[field] !== "string" || !entry[field].trim()) {
+			errors.push(`${key}: ${field} is required.`);
+		}
+	}
+
+	const actual = overrideByKey.get(key);
+	if (!actual) {
+		errors.push(`${key}: registry entry has no matching package override.`);
+	} else if (String(entry.version) !== actual.version) {
+		errors.push(`${key}: registry version ${entry.version} does not match ${actual.version}.`);
+	}
+
+	validateReviewDates(entry, key, now, errors);
+}
+
+export function validateOverrideRegistry(packageJson, registry, now = new Date()) {
+	const errors = [];
+	if (!registry || registry.schemaVersion !== OVERRIDE_REGISTRY_SCHEMA_VERSION) {
+		return {
+			valid: false,
+			errors: [`Unsupported override registry schema: ${registry?.schemaVersion}`],
+			overrideCount: 0,
+		};
+	}
+	if (!Array.isArray(registry.entries)) {
+		return {
+			valid: false,
+			errors: ["Override registry entries must be an array."],
+			overrideCount: 0,
+		};
+	}
+
+	const overrides = collectPackageOverrides(packageJson);
+	const overrideByKey = new Map(
+		overrides.map((entry) => [entryKey(entry.manager, entry.selector), entry])
+	);
+	const registryByKey = new Map();
+
+	for (const entry of registry.entries) {
+		validateRegistryEntry(entry, overrideByKey, registryByKey, now, errors);
+	}
+
+	for (const [key] of overrideByKey) {
+		if (!registryByKey.has(key)) {
+			errors.push(`${key}: package override is not registered.`);
+		}
+	}
+
+	return { valid: errors.length === 0, errors, overrideCount: overrides.length };
+}

--- a/scripts/security/override-policy.test.ts
+++ b/scripts/security/override-policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { validateOverrideRegistry } from "./override-policy.mjs";
+
+const registryEntry = {
+	manager: "pnpm.overrides",
+	selector: "example@^1",
+	version: "1.2.3",
+	reason: "상위 패키지가 안전 버전을 아직 허용하지 않습니다.",
+	introducedAt: "2026-07-01",
+	lastReviewedAt: "2026-07-01",
+	nextReviewAt: "2026-09-01",
+	removalCriteria: "상위 패키지가 1.2.3 이상을 직접 사용하면 제거합니다.",
+};
+
+describe("package override registry", () => {
+	it("override와 registry가 모두 비어 있으면 통과한다", () => {
+		const result = validateOverrideRegistry(
+			{},
+			{ schemaVersion: 1, entries: [] },
+			new Date("2026-07-21T00:00:00Z")
+		);
+
+		expect(result).toMatchObject({ valid: true, overrideCount: 0, errors: [] });
+	});
+
+	it("등록되지 않은 package override를 차단한다", () => {
+		const result = validateOverrideRegistry(
+			{ pnpm: { overrides: { "example@^1": "1.2.3" } } },
+			{ schemaVersion: 1, entries: [] },
+			new Date("2026-07-21T00:00:00Z")
+		);
+
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain(
+			"pnpm.overrides:example@^1: package override is not registered."
+		);
+	});
+
+	it("검토 기한이 지났거나 90일을 넘는 registry entry를 차단한다", () => {
+		const packageJson = { pnpm: { overrides: { "example@^1": "1.2.3" } } };
+		const overdue = validateOverrideRegistry(
+			packageJson,
+			{ schemaVersion: 1, entries: [registryEntry] },
+			new Date("2026-10-01T00:00:00Z")
+		);
+		const tooLong = validateOverrideRegistry(
+			packageJson,
+			{
+				schemaVersion: 1,
+				entries: [{ ...registryEntry, nextReviewAt: "2026-12-31" }],
+			},
+			new Date("2026-07-21T00:00:00Z")
+		);
+
+		expect(overdue.errors).toContain("pnpm.overrides:example@^1: override review is overdue.");
+		expect(tooLong.errors).toContain(
+			"pnpm.overrides:example@^1: next review must be within 90 days."
+		);
+	});
+});

--- a/scripts/security/security-gate.mjs
+++ b/scripts/security/security-gate.mjs
@@ -1,24 +1,24 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
-import {
-	countBySeverity,
-	dedupeByAlertNumber,
-	detectRepository,
-	detectToken,
-	fetchAndNormalizeAlerts,
-} from "./github-alerts.mjs";
+import { detectRepository, detectToken, fetchAndNormalizeAlerts } from "./github-alerts.mjs";
+import { buildCollectionFailureResult, buildSecurityGateResult } from "./security-policy.mjs";
 
 function parseArgs(argv) {
-	const args = { repo: null, out: "reports/security/security-gate-result.json" };
+	const args = {
+		repo: null,
+		baseline: "security/alert-baseline.json",
+		out: "reports/security/security-gate-result.json",
+	};
 
 	for (let index = 0; index < argv.length; index += 1) {
 		const token = argv[index];
 		if (token === "--repo") {
 			args.repo = argv[index + 1] ?? null;
 			index += 1;
-			continue;
-		}
-		if (token === "--out") {
+		} else if (token === "--baseline") {
+			args.baseline = argv[index + 1] ?? args.baseline;
+			index += 1;
+		} else if (token === "--out") {
 			args.out = argv[index + 1] ?? args.out;
 			index += 1;
 		}
@@ -28,124 +28,64 @@ function parseArgs(argv) {
 }
 
 function buildStepSummary(result) {
-	const disabledSources = Object.entries(result.sources)
-		.filter(([, status]) => status.status === "disabled")
-		.map(([name]) => name);
-	const disabledLine = disabledSources.length > 0 ? disabledSources.join(", ") : "none";
+	const disabledSources =
+		result.disabled_sources.length > 0 ? result.disabled_sources.join(", ") : "none";
+	const status = result.blocking_alert_count > 0 ? "FAIL" : "PASS";
 
 	return [
 		"## Security Gate",
 		`- Repository: \`${result.repository}\``,
-		`- Unique open alerts: **${result.total_unique_alerts}**`,
+		`- Policy: \`${result.policy}\``,
+		`- Current / baseline alerts: **${result.current_alert_count} / ${result.baseline_alert_count}**`,
+		`- New / resolved alerts: **${result.new_alerts.length} / ${result.resolved_alerts.length}**`,
 		`- Severity: critical=${result.severity.critical}, high=${result.severity.high}, medium=${result.severity.medium}, low=${result.severity.low}, unknown=${result.severity.unknown}`,
-		`- Disabled sources: ${disabledLine}`,
-		`- High threshold result: ${
-			result.blocking_high_count > 0 ? "FAIL" : "PASS"
-		} (count=${result.blocking_high_count})`,
+		`- High/critical gate: **${status}** (count=${result.blocking_alert_count})`,
+		`- Disabled sources: ${disabledSources}`,
 		result.collection_error ? `- Collection error: ${result.collection_error}` : null,
 	]
 		.filter(Boolean)
 		.join("\n");
 }
 
-async function writeStepSummary(markdown) {
-	const summaryPath = process.env.GITHUB_STEP_SUMMARY;
-	if (!summaryPath) {
-		return;
+async function writeResult(outputPath, result) {
+	await mkdir(dirname(outputPath), { recursive: true });
+	await writeFile(outputPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		await writeFile(process.env.GITHUB_STEP_SUMMARY, `${buildStepSummary(result)}\n`, "utf8");
 	}
-	await writeFile(summaryPath, `${markdown}\n`, "utf8");
 }
 
 async function main() {
 	const args = parseArgs(process.argv.slice(2));
 	const outputPath = resolve(args.out);
-	let repo = args.repo ?? process.env.GITHUB_REPOSITORY ?? "unknown/unknown";
+	let repository = args.repo ?? process.env.GITHUB_REPOSITORY ?? "unknown/unknown";
+	let result;
 
 	try {
-		repo = detectRepository(args.repo);
-		const token = detectToken();
-		const snapshot = await fetchAndNormalizeAlerts({ repo, token });
-		const dedupByNumber = dedupeByAlertNumber(snapshot.normalized_alerts);
-		const severity = countBySeverity(dedupByNumber.alerts);
-		const blockingHighCount = severity.critical + severity.high;
-
-		const result = {
-			repository: repo,
-			generated_at: snapshot.generated_at,
-			total_unique_alerts: dedupByNumber.alerts.length,
-			blocking_high_count: blockingHighCount,
-			medium_count: severity.medium,
-			severity,
-			sources: snapshot.sources,
-			disabled_sources: Object.entries(snapshot.sources)
-				.filter(([, status]) => status.status === "disabled")
-				.map(([name]) => name),
-			collection_error: null,
-		};
-
-		await mkdir(dirname(outputPath), { recursive: true });
-		await writeFile(outputPath, JSON.stringify(result, null, 2), "utf8");
-
-		console.log(`Repository: ${repo}`);
-		console.log(`Security gate output: ${outputPath}`);
-		console.log(`Unique open alerts: ${result.total_unique_alerts}`);
-		console.log(
-			`Severity: critical=${severity.critical}, high=${severity.high}, medium=${severity.medium}, low=${severity.low}, unknown=${severity.unknown}`
-		);
-
-		for (const [source, status] of Object.entries(snapshot.sources)) {
-			const reasonSuffix = status.reason ? ` (${status.reason})` : "";
-			console.log(
-				`Source ${source}: status=${status.status}, total=${status.total_alerts}${reasonSuffix}`
-			);
-		}
-
-		if (severity.medium > 0) {
-			console.log(
-				`::warning::Security gate detected ${severity.medium} open medium severity alert(s).`
-			);
-		}
-
-		await writeStepSummary(buildStepSummary(result));
-
-		if (blockingHighCount > 0) {
-			console.log(
-				`::error::Security gate failed: ${blockingHighCount} open high/critical alert(s) found.`
-			);
-			process.exitCode = 1;
-		}
+		repository = detectRepository(args.repo);
+		const baseline = JSON.parse(await readFile(resolve(args.baseline), "utf8"));
+		const snapshot = await fetchAndNormalizeAlerts({ repo: repository, token: detectToken() });
+		result = buildSecurityGateResult({ repository, snapshot, baseline });
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		const failureResult = {
-			repository: repo,
-			generated_at: new Date().toISOString(),
-			total_unique_alerts: 0,
-			blocking_high_count: 1,
-			medium_count: 0,
-			severity: {
-				critical: 0,
-				high: 1,
-				medium: 0,
-				low: 0,
-				unknown: 0,
-			},
-			sources: {
-				dependabot: { status: "error", reason: message, total_alerts: 0 },
-				code_scanning: { status: "error", reason: message, total_alerts: 0 },
-				secret_scanning: { status: "error", reason: message, total_alerts: 0 },
-			},
-			disabled_sources: [],
-			collection_error: message,
-		};
+		result = buildCollectionFailureResult(repository, message);
+	}
 
-		await mkdir(dirname(outputPath), { recursive: true });
-		await writeFile(outputPath, JSON.stringify(failureResult, null, 2), "utf8");
-		await writeStepSummary(buildStepSummary(failureResult));
+	await writeResult(outputPath, result);
+	console.log(buildStepSummary(result));
+	console.log(`Security gate output: ${outputPath}`);
 
-		console.error(message);
-		console.log(`Repository: ${repo}`);
-		console.log(`Security gate output: ${outputPath}`);
-		console.log("::error::Security gate failed: unable to collect alert data.");
+	if (result.severity.medium > 0 || result.new_alerts.length > 0) {
+		console.log(
+			`::warning::Security gate found ${result.new_alerts.length} new alert(s) and ${result.severity.medium} medium alert(s).`
+		);
+	}
+	if (result.blocking_alert_count > 0) {
+		console.error(
+			result.collection_error
+				? `::error::Security gate collection failed: ${result.collection_error}`
+				: `::error::Security gate blocked ${result.blocking_alert_count} high/critical alert(s).`
+		);
 		process.exitCode = 1;
 	}
 }

--- a/scripts/security/security-policy.mjs
+++ b/scripts/security/security-policy.mjs
@@ -1,0 +1,124 @@
+import { countBySeverity, dedupeAlertsByKey } from "./github-alerts.mjs";
+
+export const ALERT_BASELINE_SCHEMA_VERSION = 1;
+export const ALERT_BASELINE_POLICY = "zero-high-critical";
+
+const BLOCKING_SEVERITIES = new Set(["critical", "high"]);
+
+export function isBlockingSeverity(severity) {
+	return BLOCKING_SEVERITIES.has(String(severity ?? "unknown").toLowerCase());
+}
+
+function toBaselineEntry(alert) {
+	return {
+		key: alert.key,
+		source: alert.source,
+		severity: String(alert.severity ?? "unknown").toLowerCase(),
+		package: alert.package ?? null,
+		ghsa: alert.ghsa ?? null,
+	};
+}
+
+function sortByKey(entries) {
+	return [...entries].sort((left, right) => left.key.localeCompare(right.key));
+}
+
+export function validateAlertBaseline(baseline) {
+	if (!baseline || typeof baseline !== "object") {
+		throw new Error("Security alert baseline must be an object.");
+	}
+	if (baseline.schemaVersion !== ALERT_BASELINE_SCHEMA_VERSION) {
+		throw new Error(`Unsupported security alert baseline schema: ${baseline.schemaVersion}`);
+	}
+	if (baseline.policy !== ALERT_BASELINE_POLICY) {
+		throw new Error(`Unsupported security alert baseline policy: ${baseline.policy}`);
+	}
+	if (!Array.isArray(baseline.alerts)) {
+		throw new Error("Security alert baseline alerts must be an array.");
+	}
+
+	const keys = new Set();
+	for (const alert of baseline.alerts) {
+		if (!alert || typeof alert !== "object" || typeof alert.key !== "string" || !alert.key) {
+			throw new Error("Every baseline alert must have a non-empty key.");
+		}
+		if (keys.has(alert.key)) {
+			throw new Error(`Duplicate baseline alert key: ${alert.key}`);
+		}
+		keys.add(alert.key);
+	}
+
+	return baseline;
+}
+
+export function createAlertBaseline(alerts) {
+	const uniqueAlerts = dedupeAlertsByKey(alerts).alerts;
+	const blockingAlerts = uniqueAlerts.filter((alert) => isBlockingSeverity(alert.severity));
+	if (blockingAlerts.length > 0) {
+		throw new Error(
+			`Cannot create a zero-high baseline while ${blockingAlerts.length} high/critical alert(s) are open.`
+		);
+	}
+
+	return {
+		schemaVersion: ALERT_BASELINE_SCHEMA_VERSION,
+		policy: ALERT_BASELINE_POLICY,
+		alerts: sortByKey(uniqueAlerts.map(toBaselineEntry)),
+	};
+}
+
+export function compareAlertsWithBaseline(alerts, baseline) {
+	validateAlertBaseline(baseline);
+	const currentAlerts = sortByKey(dedupeAlertsByKey(alerts).alerts);
+	const currentByKey = new Map(currentAlerts.map((alert) => [alert.key, alert]));
+	const baselineByKey = new Map(baseline.alerts.map((alert) => [alert.key, alert]));
+
+	return {
+		currentAlerts,
+		newAlerts: currentAlerts.filter((alert) => !baselineByKey.has(alert.key)),
+		resolvedAlerts: baseline.alerts.filter((alert) => !currentByKey.has(alert.key)),
+		blockingAlerts: currentAlerts.filter((alert) => isBlockingSeverity(alert.severity)),
+	};
+}
+
+export function buildSecurityGateResult({ repository, snapshot, baseline }) {
+	const compared = compareAlertsWithBaseline(snapshot.normalized_alerts, baseline);
+	const severity = countBySeverity(compared.currentAlerts);
+	const disabledSources = Object.entries(snapshot.sources)
+		.filter(([, status]) => status.status === "disabled")
+		.map(([name]) => name);
+
+	return {
+		repository,
+		generated_at: snapshot.generated_at,
+		policy: ALERT_BASELINE_POLICY,
+		current_alert_count: compared.currentAlerts.length,
+		baseline_alert_count: baseline.alerts.length,
+		new_alerts: compared.newAlerts.map(toBaselineEntry),
+		resolved_alerts: compared.resolvedAlerts,
+		blocking_alerts: compared.blockingAlerts.map(toBaselineEntry),
+		blocking_alert_count: compared.blockingAlerts.length,
+		severity,
+		sources: snapshot.sources,
+		disabled_sources: disabledSources,
+		collection_error: null,
+	};
+}
+
+export function buildCollectionFailureResult(repository, message) {
+	return {
+		repository,
+		generated_at: new Date().toISOString(),
+		policy: ALERT_BASELINE_POLICY,
+		current_alert_count: 0,
+		baseline_alert_count: 0,
+		new_alerts: [],
+		resolved_alerts: [],
+		blocking_alerts: [],
+		blocking_alert_count: 1,
+		severity: { critical: 0, high: 1, medium: 0, low: 0, unknown: 0 },
+		sources: {},
+		disabled_sources: [],
+		collection_error: message,
+	};
+}

--- a/scripts/security/security-policy.test.ts
+++ b/scripts/security/security-policy.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildCollectionFailureResult,
+	buildSecurityGateResult,
+	compareAlertsWithBaseline,
+	createAlertBaseline,
+} from "./security-policy.mjs";
+
+const alert = (
+	key: string,
+	severity: string,
+	source = "dependabot",
+	packageName: string | null = "example-package"
+) => ({
+	key,
+	severity,
+	source,
+	package: packageName,
+	ghsa: source === "dependabot" ? "GHSA-test" : null,
+	alert_number: 1,
+});
+
+describe("security alert baseline policy", () => {
+	it("high/critical이 열려 있으면 기준선 생성을 거부한다", () => {
+		expect(() => createAlertBaseline([alert("dependabot:high", "high")])).toThrow(
+			"zero-high baseline"
+		);
+		expect(() => createAlertBaseline([alert("dependabot:critical", "critical")])).toThrow(
+			"zero-high baseline"
+		);
+	});
+
+	it("기준선과 비교해 신규·해결 경고를 결정적으로 구분한다", () => {
+		const baseline = createAlertBaseline([
+			alert("dependabot:existing", "medium"),
+			alert("code_scanning:resolved", "low", "code_scanning", null),
+		]);
+		const compared = compareAlertsWithBaseline(
+			[
+				alert("dependabot:existing", "medium"),
+				alert("secret_scanning:new", "low", "secret_scanning", null),
+			],
+			baseline
+		);
+
+		expect(compared.newAlerts.map((item: { key: string }) => item.key)).toEqual([
+			"secret_scanning:new",
+		]);
+		expect(compared.resolvedAlerts.map((item: { key: string }) => item.key)).toEqual([
+			"code_scanning:resolved",
+		]);
+		expect(compared.blockingAlerts).toEqual([]);
+	});
+
+	it("disabled scanner는 보고하되 gate를 차단하지 않는다", () => {
+		const baseline = createAlertBaseline([]);
+		const result = buildSecurityGateResult({
+			repository: "owner/repo",
+			baseline,
+			snapshot: {
+				generated_at: "2026-07-21T00:00:00.000Z",
+				normalized_alerts: [],
+				sources: {
+					dependabot: { status: "ok", total_alerts: 0 },
+					secret_scanning: { status: "disabled", total_alerts: 0 },
+				},
+			},
+		});
+
+		expect(result.blocking_alert_count).toBe(0);
+		expect(result.disabled_sources).toEqual(["secret_scanning"]);
+	});
+
+	it("수집 오류는 fail-closed 결과를 만든다", () => {
+		const result = buildCollectionFailureResult("owner/repo", "API unavailable");
+
+		expect(result.blocking_alert_count).toBe(1);
+		expect(result.collection_error).toBe("API unavailable");
+	});
+});

--- a/security/alert-baseline.json
+++ b/security/alert-baseline.json
@@ -1,0 +1,13 @@
+{
+	"schemaVersion": 1,
+	"policy": "zero-high-critical",
+	"alerts": [
+		{
+			"key": "dependabot:GHSA-qx2v-qp2m-jg93:postcss",
+			"source": "dependabot",
+			"severity": "medium",
+			"package": "postcss",
+			"ghsa": "GHSA-qx2v-qp2m-jg93"
+		}
+	]
+}

--- a/security/package-overrides.json
+++ b/security/package-overrides.json
@@ -1,0 +1,4 @@
+{
+	"schemaVersion": 1,
+	"entries": []
+}


### PR DESCRIPTION
## 변경 사항
- Dependabot·CodeQL·Secret Scanning 경고를 stable key로 정규화하고 중복을 제거합니다.
- high/critical 0건 정책의 alert baseline과 fail-closed Security Gate를 추가합니다.
- master PR과 매일 09:00 KST에 dependency audit, override 검증, GitHub alert gate를 실행합니다.
- GitGuardian false positive와 실제 secret 노출 대응 절차를 문서화합니다.

## 현재 기준선
- critical: 0
- high: 0
- medium: 1 (PostCSS)
- secret_scanning: disabled warning

## 검증
- pnpm audit --audit-level high
- pnpm security:overrides
- pnpm security:gate
- pnpm run ci
- pnpm install --frozen-lockfile
- git diff --check