### PR TITLE
crawl-history 영구 보존 정책 적용

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload unit coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-coverage
           path: coverage/
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload Playwright diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: |

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload security gate result
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: security-gate-result
           path: reports/security/security-gate-result.json

--- a/README.md
+++ b/README.md
@@ -149,9 +149,10 @@ erDiagram
 
 - 현재 스키마는 명시적 FK 제약보다 PostgreSQL RPC(`move_thread`, `bulk_move_new_threads_to_trash`)로 이동 원자성을 유지합니다.
 - `new-threads.tag`는 배열 성격의 태그 데이터를 저장합니다.
-- `crawl-history`는 `(crawl_source, url)` 유니크 인덱스로 중복 유입을 방지합니다.
+- `crawl-history`는 `(crawl_source, url)` 유니크 인덱스로 중복 유입을 영구적으로 방지합니다. 사용자 목록에서 삭제된 URL도 재수집하지 않으며, 기간 만료 삭제·아카이브·월별 파티셔닝을 적용하지 않습니다.
 - `crawl_runs`는 재시도를 포함한 한 번의 실행을 한 행으로 보존하며 90일이 지난 이력은 매일 03:15 KST에 정리합니다.
 - `crawl_alert_incidents`와 `crawl_alert_notifications`는 소스 장애 상태와 GitHub Issue 전달 outbox를 보존합니다.
+- `crawl-history` 용량 측정, 백업·복구, 성능 검증 절차는 [`docs/CRAWL_HISTORY_RETENTION.md`](docs/CRAWL_HISTORY_RETENTION.md)를 참고합니다.
 - 장애 감지 기준과 운영 절차는 [`docs/CRAWLER_ALERT_OPERATIONS.md`](docs/CRAWLER_ALERT_OPERATIONS.md)를 참고합니다.
 - 통계 API는 `new-threads` 기반 RPC(`get_new_threads_stats`)를 사용합니다.
 

--- a/docs/CRAWL_HISTORY_RETENTION.md
+++ b/docs/CRAWL_HISTORY_RETENTION.md
@@ -1,0 +1,146 @@
+# 크롤링 이력 보존 정책
+
+## 정책
+
+`public."crawl-history"`는 운영 로그가 아니라 `(crawl_source, url)` 기준의 영구 중복 방지 집합이다. `new-threads`, `quick-save`, `trash`에서 사용자가 항목을 삭제해도 이력은 삭제하지 않으며, 같은 소스에서 같은 URL이 다시 발견되어도 재수집하지 않는다.
+
+- 보존 기간: 영구
+- 만료 처리: 삭제·아카이브 없음
+- 삭제된 URL 재수집: 허용하지 않음
+- 자동 정리: `crawl-history` 대상 RPC 또는 cron job 없음
+- 파티셔닝: 적용하지 않음
+
+PostgreSQL 15의 partitioned table에서 unique constraint는 모든 partition key를 포함해야 한다. `created_at` 월별 파티셔닝을 적용하면 현재 전역 유니크 키에 `created_at`을 추가해야 하므로, 같은 URL이 다른 월에 다시 적재될 수 있다. 현재 중복 방지 계약을 유지하기 위해 단일 테이블과 `idx_crawl_history_source_url_unique`를 사용한다.
+
+## 운영 규모 측정
+
+아래 쿼리는 읽기 전용이다. 배포 전후 Supabase SQL Editor에서 실행하고 결과와 실행 시각을 운영 기록에 남긴다.
+
+### 전체·소스별 행 수와 기간
+
+```sql
+select
+	count(*) as row_count,
+	min(created_at) as first_created_at,
+	max(created_at) as last_created_at,
+	max(created_at) - min(created_at) as observed_period
+from public."crawl-history";
+
+select
+	crawl_source,
+	count(*) as row_count,
+	min(created_at) as first_created_at,
+	max(created_at) as last_created_at
+from public."crawl-history"
+group by crawl_source
+order by row_count desc;
+```
+
+### 증가량과 단순 연간 예상치
+
+```sql
+select
+	date_trunc('month', created_at) as month,
+	count(*) as added_rows
+from public."crawl-history"
+group by 1
+order by 1;
+
+select
+	count(*) filter (where created_at >= now() - interval '7 days') as rows_last_7_days,
+	count(*) filter (where created_at >= now() - interval '30 days') as rows_last_30_days,
+	count(*) filter (where created_at >= now() - interval '90 days') as rows_last_90_days,
+	round(count(*) filter (where created_at >= now() - interval '30 days') / 30.0, 2) as daily_average_30_days,
+	round(count(*) filter (where created_at >= now() - interval '30 days') / 30.0 * 365) as projected_rows_next_year
+from public."crawl-history";
+```
+
+### 테이블·인덱스 용량
+
+```sql
+select
+	pg_size_pretty(pg_relation_size('public."crawl-history"')) as table_size,
+	pg_size_pretty(pg_indexes_size('public."crawl-history"')) as indexes_size,
+	pg_size_pretty(pg_total_relation_size('public."crawl-history"')) as total_size;
+
+select
+	indexrelname as index_name,
+	pg_size_pretty(pg_relation_size(indexrelid)) as index_size,
+	idx_scan,
+	idx_tup_read,
+	idx_tup_fetch
+from pg_stat_user_indexes
+where relid = 'public."crawl-history"'::regclass
+order by pg_relation_size(indexrelid) desc;
+```
+
+`pg_stat_user_indexes`의 누적값은 통계 초기화 이후 기간만 나타내므로 측정 시각과 DB 재시작·통계 초기화 여부를 함께 기록한다. 행 수와 전체 용량의 추세를 월별로 비교하고, 저장 한도에 가까워지거나 아래 대표 조회가 더 이상 unique index를 사용하지 않을 때만 데이터 모델을 재검토한다.
+
+## 백업과 복구
+
+권한 migration 자체는 데이터를 삭제하지 않지만, 배포 전 다음 절차로 복구 가능성을 확인한다.
+
+1. Supabase Dashboard에서 최신 자동 백업 또는 PITR 복구 지점과 보존 기간을 확인한다.
+2. 저장소 밖의 접근 제한된 경로로 논리 백업을 생성한다. 이 파일에는 수집 URL이 포함되므로 암호화된 저장소에 보관한다.
+
+```powershell
+pnpm exec supabase db dump --linked --data-only --use-copy --schema public --file C:\secure-backups\applemint-public-YYYYMMDD.sql
+```
+
+3. 운영 프로젝트가 아닌 격리된 로컬 DB에서 migration을 적용하고 백업을 복원한다. `db reset`은 지정한 로컬 DB의 데이터를 지우므로 `supabase status`에서 대상이 로컬 프로젝트인지 먼저 확인한다.
+
+```powershell
+pnpm exec supabase db reset --local --no-seed
+psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" --file C:\secure-backups\applemint-public-YYYYMMDD.sql
+```
+
+4. 원본과 복원본에서 다음 검증 쿼리를 실행해 전체·소스별 행 수와 기간이 일치하는지 확인한다.
+
+```sql
+select
+	crawl_source,
+	count(*) as row_count,
+	min(created_at) as first_created_at,
+	max(created_at) as last_created_at
+from public."crawl-history"
+group by crawl_source
+order by crawl_source;
+```
+
+복원이 검증되지 않았거나 백업 시점을 확인할 수 없으면 배포를 중단한다. 예기치 않은 history 손실은 신규 크롤링을 중지한 뒤 PITR 또는 검증된 논리 백업으로 복구하고, 전체·소스별 행 수를 다시 대조한다.
+
+## 배포 후 성능 검증
+
+먼저 실제 존재하는 URL 하나를 선택한다.
+
+```sql
+select crawl_source, url
+from public."crawl-history"
+order by created_at desc
+limit 1;
+```
+
+아래 값들을 위 결과로 바꾼 뒤 실행한다. 실행 계획에서 `idx_crawl_history_source_url_unique`를 사용하는 `Index Only Scan` 또는 `Index Scan`과 1행 이하 결과를 확인한다.
+
+```sql
+explain (analyze, buffers)
+select url
+from public."crawl-history"
+where crawl_source = '실제 crawl_source'
+	and url = '실제 url';
+```
+
+마지막으로 다음 불변 조건을 확인한다.
+
+```sql
+select
+	to_regclass('public.idx_crawl_history_source_url_unique') is not null as unique_index_exists,
+	count(*) = count(distinct (crawl_source, url)) as has_no_duplicates
+from public."crawl-history";
+
+select jobname, schedule, command
+from cron.job
+where command ilike '%crawl-history%';
+```
+
+첫 쿼리는 두 값이 모두 `true`, 두 번째 쿼리는 0행이어야 한다. 기존 `applemint-clean-crawl-runs` 작업은 `crawl_runs`와 관련 알림 이력만 90일 후 정리하며 `crawl-history`에는 접근하지 않는다.

--- a/docs/CRAWL_HISTORY_RETENTION.md
+++ b/docs/CRAWL_HISTORY_RETENTION.md
@@ -87,14 +87,43 @@ order by pg_relation_size(indexrelid) desc;
 pnpm exec supabase db dump --linked --data-only --use-copy --schema public --file C:\secure-backups\applemint-public-YYYYMMDD.sql
 ```
 
-3. 운영 프로젝트가 아닌 격리된 로컬 DB에서 migration을 적용하고 백업을 복원한다. `db reset`은 지정한 로컬 DB의 데이터를 지우므로 `supabase status`에서 대상이 로컬 프로젝트인지 먼저 확인한다.
+3. 운영 프로젝트가 아닌 격리된 로컬 DB에서 migration을 적용한다. `db reset`은 지정한 로컬 DB의 데이터를 지우므로 `supabase status`에서 대상이 로컬 프로젝트인지 먼저 확인한다.
 
 ```powershell
 pnpm exec supabase db reset --local --no-seed
-psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" --file C:\secure-backups\applemint-public-YYYYMMDD.sql
 ```
 
-4. 원본과 복원본에서 다음 검증 쿼리를 실행해 전체·소스별 행 수와 기간이 일치하는지 확인한다.
+4. data-only dump를 재생하기 전에 migration이 생성한 singleton 행을 포함해 로컬 `public` 데이터를 모두 비운다. 아래 URL은 이 프로젝트의 고정된 loopback 로컬 DB 주소이며, 원격 또는 linked DB 주소로 바꾸지 않는다.
+
+```powershell
+$restoreDbUrl = "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+$restoreDbUri = [Uri]$restoreDbUrl
+if ($restoreDbUri.Host -notin @("127.0.0.1", "localhost") -or $restoreDbUri.Port -ne 54322) {
+	throw "복원 검증은 loopback 로컬 DB의 54322 포트에서만 실행할 수 있습니다."
+}
+$emptyPublicDataSql = @'
+do $$
+declare
+	table_list text;
+begin
+	select string_agg(format('%I.%I', schemaname, tablename), ', ')
+	into table_list
+	from pg_tables
+	where schemaname = 'public';
+
+	if table_list is not null then
+		execute 'truncate table ' || table_list || ' restart identity cascade';
+	end if;
+end
+$$;
+'@
+psql $restoreDbUrl --set ON_ERROR_STOP=on --command $emptyPublicDataSql
+psql $restoreDbUrl --set ON_ERROR_STOP=on --file C:\secure-backups\applemint-public-YYYYMMDD.sql
+```
+
+전체 `public` 데이터와 identity 값을 비운 뒤 복원하므로 migration에 포함된 초기 행과 data-only dump가 충돌하지 않는다. `ON_ERROR_STOP`은 duplicate key 등 첫 SQL 오류에서 복원을 즉시 중단한다.
+
+5. 원본과 복원본에서 다음 검증 쿼리를 실행해 전체·소스별 행 수와 기간이 일치하는지 확인한다.
 
 ```sql
 select

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
 	},
 	"pnpm": {
 		"overrides": {
-			"next>postcss": "8.5.20"
+			"next>postcss": "8.5.20",
+			"next>sharp": "0.35.3"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   next>postcss: 8.5.20
+  next>sharp: 0.35.3
 
 importers:
 
@@ -46,7 +47,7 @@ importers:
         version: 4.4.0
       geist:
         specifier: ^1.7.0
-        version: 1.7.0(next@16.2.10(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 1.7.0(next@16.2.10(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       linkifyjs:
         specifier: ^4.3.2
         version: 4.3.2
@@ -55,7 +56,7 @@ importers:
         version: 0.577.0(react@19.2.4)
       next:
         specifier: 16.2.10
-        version: 16.2.10(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.10(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -236,152 +237,161 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -1991,9 +2001,19 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2340,98 +2360,108 @@ snapshots:
   '@img/colour@1.1.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.34.5':
+  '@img/sharp-darwin-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.5':
+  '@img/sharp-darwin-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.3.2
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
+  '@img/sharp-libvips-darwin-x64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
+  '@img/sharp-libvips-linux-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
+  '@img/sharp-libvips-linux-arm@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
+  '@img/sharp-libvips-linux-s390x@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+  '@img/sharp-libvips-linux-x64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-linux-arm64@0.34.5':
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-arm@0.34.5':
+  '@img/sharp-linux-arm@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.3.2
     optional: true
 
-  '@img/sharp-linux-ppc64@0.34.5':
+  '@img/sharp-linux-ppc64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-riscv64@0.34.5':
+  '@img/sharp-linux-riscv64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-s390x@0.34.5':
+  '@img/sharp-linux-s390x@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.3.2
     optional: true
 
-  '@img/sharp-linux-x64@0.34.5':
+  '@img/sharp-linux-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.3.2
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
+  '@img/sharp-linuxmusl-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
+  '@img/sharp-linuxmusl-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
     optional: true
 
-  '@img/sharp-wasm32@0.34.5':
+  '@img/sharp-wasm32@0.35.3':
     dependencies:
       '@emnapi/runtime': 1.11.1
     optional: true
 
-  '@img/sharp-win32-arm64@0.34.5':
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.5':
+  '@img/sharp-win32-arm64@0.35.3':
     optional: true
 
-  '@img/sharp-win32-x64@0.34.5':
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -3445,9 +3475,9 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  geist@1.7.0(next@16.2.10(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  geist@1.7.0(next@16.2.10(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
-      next: 16.2.10(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.10(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   get-nonce@1.0.1: {}
 
@@ -3634,7 +3664,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.10(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.10(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
@@ -3654,9 +3684,10 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.10
       '@next/swc-win32-x64-msvc': 16.2.10
       '@playwright/test': 1.61.1
-      sharp: 0.34.5
+      sharp: 0.35.3(@types/node@24.13.3)
     transitivePeerDependencies:
       - '@babel/core'
+      - '@types/node'
       - babel-plugin-macros
 
   nth-check@2.1.1:
@@ -3810,36 +3841,41 @@ snapshots:
 
   semver@7.7.4: {}
 
-  sharp@0.34.5:
+  semver@7.8.5:
+    optional: true
+
+  sharp@0.35.3(@types/node@24.13.3):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 24.13.3
     optional: true
 
   shebang-command@2.0.0:

--- a/security/package-overrides.json
+++ b/security/package-overrides.json
@@ -10,6 +10,16 @@
 			"lastReviewedAt": "2026-07-21",
 			"nextReviewAt": "2026-10-19",
 			"removalCriteria": "Remove when Next.js depends on postcss 8.5.10 or later."
+		},
+		{
+			"manager": "pnpm.overrides",
+			"selector": "next>sharp",
+			"version": "0.35.3",
+			"reason": "Next 16.2.10 restricts sharp to vulnerable 0.34.x releases (GHSA-f88m-g3jw-g9cj).",
+			"introducedAt": "2026-07-22",
+			"lastReviewedAt": "2026-07-22",
+			"nextReviewAt": "2026-10-20",
+			"removalCriteria": "Remove when Next.js depends on sharp 0.35.0 or later."
 		}
 	]
 }

--- a/supabase/migrations/20260722100000_preserve_crawl_history.sql
+++ b/supabase/migrations/20260722100000_preserve_crawl_history.sql
@@ -1,0 +1,6 @@
+-- crawl-history는 사용자 목록과 별개로 영구 중복 방지 키를 보존한다.
+revoke all on table public."crawl-history" from service_role;
+grant select, insert on table public."crawl-history" to service_role;
+
+revoke all on sequence public."crawl-history_id_seq" from service_role;
+grant usage, select on sequence public."crawl-history_id_seq" to service_role;

--- a/supabase/tests/p4_crawl_history_retention.test.sql
+++ b/supabase/tests/p4_crawl_history_retention.test.sql
@@ -1,0 +1,124 @@
+begin;
+
+select plan(16);
+
+select ok(
+	has_table_privilege('service_role', 'public."crawl-history"', 'SELECT,INSERT'),
+	'service role retains the crawl history privileges required for ingest'
+);
+select ok(
+	not has_table_privilege('service_role', 'public."crawl-history"', 'UPDATE')
+		and not has_table_privilege('service_role', 'public."crawl-history"', 'DELETE')
+		and not has_table_privilege('service_role', 'public."crawl-history"', 'TRUNCATE'),
+	'service role cannot mutate or delete permanent crawl history'
+);
+select ok(
+	has_sequence_privilege('service_role', 'public."crawl-history_id_seq"', 'USAGE,SELECT'),
+	'service role retains the sequence privileges required for ingest'
+);
+select ok(
+	not has_sequence_privilege('service_role', 'public."crawl-history_id_seq"', 'UPDATE'),
+	'service role cannot advance the crawl history sequence directly'
+);
+
+set local role service_role;
+select is(
+	(public.ingest_crawl_items(
+		'arcalive',
+		'[{"url":"https://retention.test/permanent","title":"permanent history","host":"retention.test"}]'::jsonb
+	) ->> 'insertedCount')::integer,
+	1,
+	'first ingest inserts a previously unseen URL'
+);
+reset role;
+
+select is(
+	(select count(*) from public."crawl-history" where url = 'https://retention.test/permanent'),
+	1::bigint,
+	'first ingest creates one permanent history row'
+);
+select is(
+	(select count(*) from public."new-threads" where url = 'https://retention.test/permanent'),
+	1::bigint,
+	'first ingest creates one visible thread'
+);
+
+delete from public."new-threads" where url = 'https://retention.test/permanent';
+
+set local role service_role;
+select is(
+	(public.ingest_crawl_items(
+		'arcalive',
+		'[{"url":"https://retention.test/permanent","title":"recrawled history","host":"retention.test"}]'::jsonb
+	) ->> 'insertedCount')::integer,
+	0,
+	'a removed visible URL is not inserted again'
+);
+select is(
+	(public.ingest_crawl_items(
+		'arcalive',
+		'[{"url":"https://retention.test/permanent","title":"recrawled history","host":"retention.test"}]'::jsonb
+	) ->> 'skippedCount')::integer,
+	1,
+	'a removed visible URL is reported as skipped'
+);
+reset role;
+
+select is(
+	(select count(*) from public."crawl-history" where url = 'https://retention.test/permanent'),
+	1::bigint,
+	'repeated ingest preserves exactly one history row'
+);
+select is(
+	(select count(*) from public."new-threads" where url = 'https://retention.test/permanent'),
+	0::bigint,
+	'repeated ingest does not recreate the removed visible thread'
+);
+
+insert into public."crawl-history" (created_at, url, crawl_source, host)
+values (
+	now() - interval '400 days',
+	'https://retention.test/old-history',
+	'battlepage',
+	'retention.test'
+);
+
+select lives_ok(
+	$$select public.cleanup_crawl_runs()$$,
+	'crawl run cleanup completes while permanent history exists'
+);
+select is(
+	(select count(*) from public."crawl-history" where url = 'https://retention.test/old-history'),
+	1::bigint,
+	'crawl run cleanup preserves old crawl history'
+);
+select is(
+	(
+		select count(*)
+		from pg_partitioned_table
+		where partrelid = 'public."crawl-history"'::regclass
+	),
+	0::bigint,
+	'crawl history remains an unpartitioned table'
+);
+select ok(
+	exists (
+		select 1
+		from pg_index
+		where indrelid = 'public."crawl-history"'::regclass
+			and indexrelid = 'public.idx_crawl_history_source_url_unique'::regclass
+			and indisunique
+	),
+	'crawl history retains its source and URL unique index'
+);
+select ok(
+	not exists (
+		select 1
+		from cron.job
+		where command ilike '%crawl-history%'
+	),
+	'no scheduled job deletes or archives crawl history'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## 요약
- `crawl-history`를 운영 로그가 아닌 영구 중복 방지 상태로 명확히 문서화했습니다.
- `service_role`의 `crawl-history` 권한을 `SELECT, INSERT`로 제한하고 `UPDATE/DELETE/TRUNCATE` 권한을 제거하는 migration을 추가했습니다.
- 삭제된 사용자 목록 URL이 재수집되지 않고, 오래된 crawl history가 cleanup 대상이 아니며, 파티셔닝/cron 삭제 작업이 없음을 검증하는 SQL 테스트를 추가했습니다.

## 문서
- README에 `crawl-history` 영구 보존 정책과 운영 문서 링크를 반영했습니다.
- `docs/CRAWL_HISTORY_RETENTION.md`에 용량 측정, 백업·복구, 배포 후 성능 검증 절차를 추가했습니다.

## 테스트
- `supabase/tests/p4_crawl_history_retention.test.sql` 추가