### PR TITLE
Next에서 크롤링 파이프라인 직접 실행

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,19 @@
 ## 아키텍처 개요
 
 1. UI(`/main/setting`)에서 수동 크롤링 호출
-2. `POST /api/crawl/manual`이 DB의 단일 소유자 권한을 확인한 뒤 Supabase Edge Function(`crawl-source`) 호출
-3. Edge Function이 `begin_crawl_run`으로 global DB lock과 실행 이력을 원자적으로 생성하고 `POST /api/crawl` 내부 API 호출
+2. `POST /api/crawl/manual`이 DB의 단일 소유자 권한을 확인하고 Next 크롤링 파이프라인 실행
+3. Next가 `begin_crawl_run`으로 global DB lock과 실행 이력을 원자적으로 생성하고 소스 크롤러 실행
 4. 크롤링 결과를 `filter-keyword` 기준으로 필터링/타입 분류
 5. `ingest_crawl_items` RPC가 `crawl-history` claim과 `new-threads` 적재를 하나의 트랜잭션으로 확정
 6. `finish_crawl_run`이 결과 저장과 lock 해제를 원자적으로 완료
 7. UI는 스레드 API와 `GET /api/crawl/runs`로 목록·운영 이력을 조회
+
+전환 기간에는 `CRAWL_EXECUTION_MODE=edge`로 기존 Edge Function 경로를 사용할 수 있습니다. 운영
+전환은 `next`로 진행하며, 1주간 rollback 경로를 유지한 뒤 Edge Function과 내부 `/api/crawl`을
+제거합니다.
+
+수동 크롤링은 완료 응답을 기다리는 동기 방식이며 global DB lock으로 중복 실행을 방지합니다.
+현재 단일 소유자·단일 실행 구조에서는 별도 작업 큐를 사용하지 않습니다.
 
 ## 프로젝트 구조
 
@@ -168,7 +175,7 @@ erDiagram
 - 소스 장애 대비 재시도/로그 전략 유지 (`retryOperation`, `logger.ts`)
 
 ### 2) 데이터 분류/필터 정책 관리
-- 타입 분류 기준은 `supabase/functions/crawl-source/index.ts`의 `defineType`에서 처리
+- 타입 분류 기준은 `app/api/crawl/pipeline-helpers.ts`의 `defineType`에서 처리
 - 무시 키워드/분류 키워드는 DB `filter-keyword` 테이블에서 제어
 
 ### 3) 조회 성능 및 통계 로직
@@ -208,8 +215,9 @@ erDiagram
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 - `SUPABASE_SERVICE_ROLE_KEY` (서버 전용)
 - `SUPABASE_URL` (manual crawl fallback)
-- `CRAWL_INTERNAL_SECRET` (Next/Edge에 동일하게 설정하는 32바이트 이상 내부 secret)
-- `CRAWL_API_BASE_URL` (Edge Function -> 내부 크롤링 API 주소)
+- `CRAWL_EXECUTION_MODE` (`edge` 또는 `next`; 1주간 전환 후 `next` 고정)
+- `CRAWL_INTERNAL_SECRET` (전환 기간에만 Next/Edge에 동일하게 설정하는 32바이트 이상 secret)
+- `CRAWL_API_BASE_URL` (전환 기간의 Edge Function -> 내부 크롤링 API 주소)
 - `DEBUG_CRAWL`, `LOG_LEVEL`
 - `GITHUB_TOKEN` 또는 `GH_TOKEN` (보안 스크립트 실행 시)
 - GitHub Actions variable `SUPABASE_URL`, secret `SUPABASE_SERVICE_ROLE_KEY` (Crawler Health workflow)

--- a/app/api/crawl/crawl-runner.ts
+++ b/app/api/crawl/crawl-runner.ts
@@ -1,0 +1,45 @@
+import { crawlArcalive } from "./arcalive";
+import { crawlBattlepage } from "./battlepage";
+import {
+	aggregateCrawlAttempts,
+	type CrawlExecutionResult,
+	type CrawlSourceResult,
+	type CrawlTarget,
+} from "./contracts";
+import { crawlInsagirl } from "./insagirl";
+import { crawlIssuelink } from "./issuelink";
+import { debugLog } from "./logger";
+
+type Crawler = () => Promise<CrawlSourceResult>;
+
+const CRAWLERS: Record<CrawlTarget, Crawler> = {
+	arcalive: crawlArcalive,
+	battlepage: crawlBattlepage,
+	insagirl: crawlInsagirl,
+	issuelink: crawlIssuelink,
+};
+
+export async function runCrawlerWithRetry(
+	target: CrawlTarget,
+	crawler: Crawler = CRAWLERS[target],
+	delay: (milliseconds: number) => Promise<void> = (milliseconds) =>
+		new Promise((resolve) => setTimeout(resolve, milliseconds))
+): Promise<CrawlExecutionResult> {
+	const attempts: CrawlSourceResult[] = [];
+
+	for (let attempt = 1; attempt <= 2; attempt += 1) {
+		const result = await crawler();
+		attempts.push(result);
+		if (result.succeeded > 0) {
+			return aggregateCrawlAttempts(attempts);
+		}
+
+		if (attempt < 2) {
+			const delayMs = 1000 * 2 ** (attempt - 1);
+			debugLog(`[Crawl] ${target} 전체 요청 실패, ${delayMs}ms 후 재시도`);
+			await delay(delayMs);
+		}
+	}
+
+	return aggregateCrawlAttempts(attempts);
+}

--- a/app/api/crawl/manual/route.test.ts
+++ b/app/api/crawl/manual/route.test.ts
@@ -2,11 +2,38 @@ import type { NextRequest } from "next/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const createClientMock = vi.hoisted(() => vi.fn());
+const createServiceRoleClientMock = vi.hoisted(() => vi.fn());
+const executeCrawlPipelineMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/utils/supabase/server", () => ({
 	createClient: createClientMock,
 }));
 
+vi.mock("@/utils/supabase/service-role", () => ({
+	createServiceRoleClient: createServiceRoleClientMock,
+}));
+
+vi.mock("../pipeline", () => {
+	class MockCrawlPipelineError extends Error {
+		constructor(
+			message: string,
+			readonly httpStatus: number,
+			readonly stage: string,
+			readonly crawlData: unknown = null,
+			readonly runId?: string,
+			readonly activeRunId?: string | null
+		) {
+			super(message);
+		}
+	}
+
+	return {
+		CrawlPipelineError: MockCrawlPipelineError,
+		executeCrawlPipeline: executeCrawlPipelineMock,
+	};
+});
+
+import { CrawlPipelineError } from "../pipeline";
 import { POST } from "./route";
 
 const INTERNAL_SECRET = "0123456789abcdef0123456789abcdef";
@@ -45,6 +72,9 @@ describe("POST /api/crawl/manual", () => {
 		vi.stubEnv("SUPABASE_URL", "https://project.supabase.co");
 		vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
 		vi.stubEnv("CRAWL_INTERNAL_SECRET", INTERNAL_SECRET);
+		vi.stubEnv("CRAWL_EXECUTION_MODE", "edge");
+		createServiceRoleClientMock.mockReturnValue({ kind: "service-role-client" });
+		executeCrawlPipelineMock.mockReset();
 		mockAccess();
 	});
 
@@ -130,5 +160,93 @@ describe("POST /api/crawl/manual", () => {
 		const response = await POST(createRequest("arcalive"));
 
 		expect(response.status).toBe(504);
+	});
+
+	it("next 모드에서는 Edge 호출 없이 통합 파이프라인 결과를 반환한다", async () => {
+		vi.stubEnv("CRAWL_EXECUTION_MODE", "next");
+		executeCrawlPipelineMock.mockResolvedValue({
+			runId: "42",
+			status: "succeeded",
+			target: "arcalive",
+			insertedCount: 3,
+			skippedCount: 1,
+			warningCount: 0,
+			durationMs: 123,
+		});
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const response = await POST(createRequest("arcalive"));
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({ runId: "42", insertedCount: 3 });
+		expect(executeCrawlPipelineMock).toHaveBeenCalledWith(
+			"arcalive",
+			createServiceRoleClientMock.mock.results[0].value
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("next 모드의 lock 충돌은 기존 409 응답 계약을 유지한다", async () => {
+		vi.stubEnv("CRAWL_EXECUTION_MODE", "next");
+		executeCrawlPipelineMock.mockRejectedValue(
+			new CrawlPipelineError(
+				"다른 크롤링 작업이 이미 실행 중입니다.",
+				409,
+				"unknown",
+				null,
+				undefined,
+				"41"
+			)
+		);
+
+		const response = await POST(createRequest("arcalive"));
+
+		expect(response.status).toBe(409);
+		expect(await response.json()).toEqual({
+			error: "다른 크롤링 작업이 이미 실행 중입니다.",
+			activeRunId: "41",
+		});
+	});
+
+	it("next 모드의 timeout 실패는 runId와 504를 반환한다", async () => {
+		vi.stubEnv("CRAWL_EXECUTION_MODE", "next");
+		executeCrawlPipelineMock.mockRejectedValue(
+			new CrawlPipelineError("timeout", 504, "source", null, "42")
+		);
+
+		const response = await POST(createRequest("arcalive"));
+
+		expect(response.status).toBe(504);
+		expect(await response.json()).toEqual({
+			runId: "42",
+			status: "failed",
+			error: "크롤링 요청 시간이 초과되었습니다.",
+		});
+	});
+
+	it("next 모드의 service-role 설정 오류는 503을 반환한다", async () => {
+		vi.stubEnv("CRAWL_EXECUTION_MODE", "next");
+		createServiceRoleClientMock.mockImplementation(() => {
+			throw new Error("missing service role key");
+		});
+
+		const response = await POST(createRequest("arcalive"));
+
+		expect(response.status).toBe(503);
+		expect(await response.json()).toEqual({
+			error: "수동 크롤링 서버 설정이 완료되지 않았습니다.",
+		});
+		expect(executeCrawlPipelineMock).not.toHaveBeenCalled();
+	});
+
+	it("next 모드의 예상하지 못한 실행 오류는 500을 반환한다", async () => {
+		vi.stubEnv("CRAWL_EXECUTION_MODE", "next");
+		executeCrawlPipelineMock.mockRejectedValue(new Error("unexpected"));
+
+		const response = await POST(createRequest("arcalive"));
+
+		expect(response.status).toBe(500);
+		expect(await response.json()).toEqual({ error: "크롤링 처리에 실패했습니다." });
 	});
 });

--- a/app/api/crawl/manual/route.ts
+++ b/app/api/crawl/manual/route.ts
@@ -1,36 +1,65 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { checkApplemintOwner } from "@/utils/supabase/owner-access";
 import { createClient } from "@/utils/supabase/server";
+import { createServiceRoleClient } from "@/utils/supabase/service-role";
 import { isCrawlTarget } from "../contracts";
 import { hasMinimumInternalSecretLength } from "../internal-auth";
+import { CrawlPipelineError, executeCrawlPipeline } from "../pipeline";
 
 const EDGE_REQUEST_TIMEOUT_MS = 120_000;
+
+export const maxDuration = 60;
+
+type CrawlExecutionMode = "edge" | "next";
 
 function isTimeoutError(error: unknown) {
 	return error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError");
 }
 
-export async function POST(request: NextRequest): Promise<NextResponse> {
+function getExecutionMode(): CrawlExecutionMode {
+	const configuredMode = process.env.CRAWL_EXECUTION_MODE?.toLowerCase();
+	if (!configuredMode || configuredMode === "edge") {
+		return "edge";
+	}
+	if (configuredMode === "next") {
+		return "next";
+	}
+	console.error("[crawl] invalid_execution_mode", { configuredMode });
+	return "edge";
+}
+
+function pipelineErrorResponse(error: CrawlPipelineError) {
+	if (error.httpStatus === 409) {
+		return NextResponse.json(
+			{
+				error: error.message,
+				activeRunId: error.activeRunId ?? null,
+			},
+			{ status: 409 }
+		);
+	}
+
+	const message =
+		error.httpStatus === 504 ? "크롤링 요청 시간이 초과되었습니다." : "크롤링 처리에 실패했습니다.";
+	return NextResponse.json(
+		{
+			...(error.runId ? { runId: error.runId, status: "failed" } : {}),
+			error: message,
+		},
+		{ status: error.httpStatus }
+	);
+}
+
+async function invokeLegacyEdge(target: string) {
 	const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
 	const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 	const internalSecret = process.env.CRAWL_INTERNAL_SECRET;
-
-	const supabase = await createClient();
-	const ownerAccess = await checkApplemintOwner(supabase);
-	if (ownerAccess.kind !== "owner") {
-		return NextResponse.json({ error: ownerAccess.message }, { status: ownerAccess.status });
-	}
 
 	if (!supabaseUrl || !serviceRoleKey || !hasMinimumInternalSecretLength(internalSecret)) {
 		return NextResponse.json(
 			{ error: "수동 크롤링 서버 설정이 완료되지 않았습니다." },
 			{ status: 503 }
 		);
-	}
-
-	const body = (await request.json().catch(() => null)) as { target?: unknown } | null;
-	if (!isCrawlTarget(body?.target)) {
-		return NextResponse.json({ error: "지원하지 않는 크롤링 대상입니다." }, { status: 400 });
 	}
 
 	try {
@@ -42,7 +71,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 				"Content-Type": "application/json",
 				"x-applemint-internal-secret": internalSecret,
 			},
-			body: JSON.stringify({ target: body.target }),
+			body: JSON.stringify({ target }),
 			signal: AbortSignal.timeout(EDGE_REQUEST_TIMEOUT_MS),
 		});
 		const data = (await response.json().catch(() => null)) as Record<string, unknown> | null;
@@ -60,5 +89,48 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 			error instanceof Error ? error.message : "Unknown error"
 		);
 		return NextResponse.json({ error: "크롤러 API 호출에 실패했습니다." }, { status: 500 });
+	}
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+	const supabase = await createClient();
+	const ownerAccess = await checkApplemintOwner(supabase);
+	if (ownerAccess.kind !== "owner") {
+		return NextResponse.json({ error: ownerAccess.message }, { status: ownerAccess.status });
+	}
+
+	const body = (await request.json().catch(() => null)) as { target?: unknown } | null;
+	if (!isCrawlTarget(body?.target)) {
+		return NextResponse.json({ error: "지원하지 않는 크롤링 대상입니다." }, { status: 400 });
+	}
+
+	if (getExecutionMode() === "edge") {
+		return invokeLegacyEdge(body.target);
+	}
+
+	let serviceRoleClient: ReturnType<typeof createServiceRoleClient>;
+	try {
+		serviceRoleClient = createServiceRoleClient();
+	} catch (error) {
+		console.error("[crawl] next_configuration_failed", {
+			message: error instanceof Error ? error.message : "Unknown error",
+		});
+		return NextResponse.json(
+			{ error: "수동 크롤링 서버 설정이 완료되지 않았습니다." },
+			{ status: 503 }
+		);
+	}
+
+	try {
+		const result = await executeCrawlPipeline(body.target, serviceRoleClient);
+		return NextResponse.json(result);
+	} catch (error) {
+		if (error instanceof CrawlPipelineError) {
+			return pipelineErrorResponse(error);
+		}
+		console.error("[crawl] unexpected_request_failure", {
+			message: error instanceof Error ? error.message : "Unknown error",
+		});
+		return NextResponse.json({ error: "크롤링 처리에 실패했습니다." }, { status: 500 });
 	}
 }

--- a/app/api/crawl/pipeline-helpers.test.ts
+++ b/app/api/crawl/pipeline-helpers.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { CrawlExecutionResult } from "./contracts";
+import {
+	chunkUrlsForHistoryQuery,
+	createRunResult,
+	dedupeByUrl,
+	defineType,
+	getCompletedRunStatus,
+} from "./pipeline-helpers";
+
+function createExecutionResult(
+	overrides: Partial<CrawlExecutionResult> = {}
+): CrawlExecutionResult {
+	return {
+		items: [],
+		attempted: 1,
+		succeeded: 1,
+		failures: [],
+		warnings: [],
+		parserObservations: [],
+		retryCount: 0,
+		parserValidCount: 0,
+		parserMinimumCount: 0,
+		...overrides,
+	};
+}
+
+describe("crawl pipeline helpers", () => {
+	it("URL 중복 제거는 첫 번째 항목을 유지한다", () => {
+		expect(
+			dedupeByUrl([
+				{ url: "https://example.com/1", title: "first" },
+				{ url: "https://example.com/1", title: "duplicate" },
+			])
+		).toEqual([{ url: "https://example.com/1", title: "first" }]);
+	});
+
+	it("필터 키워드 method로 타입을 분류하고 기본값은 normal이다", () => {
+		const filters = [{ value: "example.com", method: "source" }];
+		expect(defineType("https://example.com/post", filters)).toBe("source");
+		expect(defineType("https://other.test/post", filters)).toBe("normal");
+	});
+
+	it("history 조회 URL을 항목 수와 인코딩 길이 기준으로 분할한다", () => {
+		const urls = Array.from(
+			{ length: 306 },
+			(_, index) => `https://example.com/${index}?title=${"가".repeat(20)}`
+		);
+		const chunks = chunkUrlsForHistoryQuery(urls);
+
+		expect(chunks.flat()).toEqual(urls);
+		expect(chunks.every((chunk) => chunk.length <= 200)).toBe(true);
+		expect(
+			chunks.every(
+				(chunk) =>
+					chunk.length === 1 ||
+					chunk.reduce((total, url) => total + encodeURIComponent(url).length + 3, 0) <= 6000
+			)
+		).toBe(true);
+	});
+
+	it("실패 또는 경고가 있는 완료 실행은 partial로 기록한다", () => {
+		expect(getCompletedRunStatus(createExecutionResult())).toBe("succeeded");
+		expect(
+			getCompletedRunStatus(
+				createExecutionResult({
+					warnings: [
+						{
+							url: "https://example.com",
+							code: "empty-list",
+							message: "empty",
+							count: 0,
+							attempt: 1,
+						},
+					],
+				})
+			)
+		).toBe("partial");
+	});
+
+	it("실행 이력 집계에서 timeout을 network와 중복 집계하지 않는다", () => {
+		const result = createRunResult(
+			"failed",
+			createExecutionResult({
+				failures: [
+					{
+						url: "https://example.com",
+						message: "timeout",
+						kind: "network",
+						timeout: true,
+						attempt: 1,
+					},
+				],
+			}),
+			0,
+			0,
+			"source",
+			"failed"
+		);
+
+		expect(result).toMatchObject({
+			failureCount: 1,
+			networkFailureCount: 0,
+			timeoutFailureCount: 1,
+			errorStage: "source",
+		});
+	});
+});

--- a/app/api/crawl/pipeline-helpers.ts
+++ b/app/api/crawl/pipeline-helpers.ts
@@ -1,0 +1,109 @@
+import type { CrawlExecutionResult } from "./contracts";
+
+export interface FilterKeyword {
+	value: string;
+	method: string;
+}
+
+export type CrawlErrorStage = "source" | "filter" | "history" | "ingest" | "unknown";
+
+export function defineType(value: string, filterList: FilterKeyword[]) {
+	return filterList.find((filter) => value.includes(filter.value))?.method || "normal";
+}
+
+export function dedupeByUrl<T extends { url: string }>(items: T[]) {
+	const deduped = new Map<string, T>();
+	for (const item of items) {
+		if (item.url && !deduped.has(item.url)) {
+			deduped.set(item.url, item);
+		}
+	}
+	return Array.from(deduped.values());
+}
+
+export function chunkUrlsForHistoryQuery(
+	urls: string[],
+	maxItems = 200,
+	maxEncodedCharacters = 6000
+) {
+	const chunks: string[][] = [];
+	let currentChunk: string[] = [];
+	let currentEncodedCharacters = 0;
+
+	for (const url of urls) {
+		const encodedCharacters = encodeURIComponent(url).length + 3;
+		const exceedsLimit =
+			currentChunk.length > 0 &&
+			(currentChunk.length >= maxItems ||
+				currentEncodedCharacters + encodedCharacters > maxEncodedCharacters);
+		if (exceedsLimit) {
+			chunks.push(currentChunk);
+			currentChunk = [];
+			currentEncodedCharacters = 0;
+		}
+		currentChunk.push(url);
+		currentEncodedCharacters += encodedCharacters;
+	}
+
+	if (currentChunk.length > 0) {
+		chunks.push(currentChunk);
+	}
+	return chunks;
+}
+
+function countCrawlFailureKinds(failures: CrawlExecutionResult["failures"]) {
+	let networkFailureCount = 0;
+	let parserFailureCount = 0;
+	let timeoutFailureCount = 0;
+
+	for (const failure of failures) {
+		if (failure.timeout === true) {
+			timeoutFailureCount += 1;
+		} else if (failure.kind === "parser") {
+			parserFailureCount += 1;
+		} else {
+			networkFailureCount += 1;
+		}
+	}
+
+	return { networkFailureCount, parserFailureCount, timeoutFailureCount };
+}
+
+export function getCompletedRunStatus(crawlData: CrawlExecutionResult) {
+	return crawlData.failures.length > 0 || crawlData.warnings.length > 0
+		? ("partial" as const)
+		: ("succeeded" as const);
+}
+
+export function createRunResult(
+	status: "succeeded" | "partial" | "failed",
+	crawlData: CrawlExecutionResult | null,
+	insertedCount: number,
+	skippedCount: number,
+	errorStage: CrawlErrorStage | null = null,
+	errorMessage: string | null = null
+) {
+	const failures = crawlData?.failures ?? [];
+	const warnings = crawlData?.warnings ?? [];
+	const parserObservations = crawlData?.parserObservations ?? [];
+
+	return {
+		status,
+		retryCount: Math.max(0, Number(crawlData?.retryCount ?? 0)),
+		attemptedCount: Math.max(0, Number(crawlData?.attempted ?? 0)),
+		succeededCount: Math.max(0, Number(crawlData?.succeeded ?? 0)),
+		extractedCount: crawlData?.items.length ?? 0,
+		insertedCount: Math.max(0, insertedCount),
+		skippedCount: Math.max(0, skippedCount),
+		warningCount: warnings.length,
+		failureCount: failures.length,
+		...countCrawlFailureKinds(failures),
+		parserValidCount: Math.max(0, Number(crawlData?.parserValidCount ?? 0)),
+		parserMinimumCount: Math.max(0, Number(crawlData?.parserMinimumCount ?? 0)),
+		warnings,
+		failures,
+		parserObservations,
+		errorStage,
+		errorMessage,
+	};
+}

--- a/app/api/crawl/pipeline.test.ts
+++ b/app/api/crawl/pipeline.test.ts
@@ -1,0 +1,170 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, it, vi } from "vitest";
+import type { CrawlExecutionResult } from "./contracts";
+import { CrawlPipelineError, executeCrawlPipeline } from "./pipeline";
+
+function createExecutionResult(
+	overrides: Partial<CrawlExecutionResult> = {}
+): CrawlExecutionResult {
+	return {
+		items: [
+			{
+				url: "https://example.com/1",
+				title: "one",
+				description: null,
+				host: "example.com",
+			},
+		],
+		attempted: 1,
+		succeeded: 1,
+		failures: [],
+		warnings: [],
+		parserObservations: [],
+		retryCount: 0,
+		parserValidCount: 1,
+		parserMinimumCount: 1,
+		...overrides,
+	};
+}
+
+function createSupabaseMock({
+	lockAcquired = true,
+	finishError = false,
+}: {
+	lockAcquired?: boolean;
+	finishError?: boolean;
+} = {}) {
+	const rpc = vi.fn(async (name: string, parameters: Record<string, unknown>) => {
+		switch (name) {
+			case "begin_crawl_run":
+				return {
+					data: lockAcquired
+						? { acquired: true, runId: "42" }
+						: { acquired: false, activeRunId: "41" },
+					error: null,
+				};
+			case "ingest_crawl_items":
+				return { data: { insertedCount: 1, skippedCount: 0 }, error: null };
+			case "finish_crawl_run":
+				return finishError
+					? { data: null, error: { message: "finish failed" } }
+					: { data: { durationMs: 123 }, error: null };
+			case "release_crawl_lock":
+				return { data: true, error: null };
+			default:
+				throw new Error(`Unexpected RPC: ${name} ${JSON.stringify(parameters)}`);
+		}
+	});
+	const from = vi.fn((table: string) => {
+		if (table === "filter-keyword") {
+			return {
+				select: vi.fn().mockResolvedValue({
+					data: [{ value: "example.com", method: "source" }],
+					error: null,
+				}),
+			};
+		}
+		if (table === "crawl-history") {
+			return {
+				select: vi.fn(() => ({
+					eq: vi.fn(() => ({
+						in: vi.fn().mockResolvedValue({ data: [], error: null }),
+					})),
+				})),
+			};
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	return {
+		client: { rpc, from } as unknown as SupabaseClient,
+		rpc,
+	};
+}
+
+describe("executeCrawlPipeline", () => {
+	it("크롤링부터 원자적 적재와 실행 이력 종료까지 한 경로에서 처리한다", async () => {
+		const { client, rpc } = createSupabaseMock();
+		const runCrawler = vi.fn().mockResolvedValue(createExecutionResult());
+
+		await expect(executeCrawlPipeline("arcalive", client, runCrawler)).resolves.toEqual({
+			runId: "42",
+			status: "succeeded",
+			target: "arcalive",
+			insertedCount: 1,
+			skippedCount: 0,
+			warningCount: 0,
+			durationMs: 123,
+		});
+		expect(rpc).toHaveBeenCalledWith(
+			"ingest_crawl_items",
+			expect.objectContaining({
+				p_crawl_source: "arcalive",
+				p_items: [expect.objectContaining({ type: "source" })],
+			})
+		);
+		expect(rpc).toHaveBeenCalledWith(
+			"finish_crawl_run",
+			expect.objectContaining({
+				p_result: expect.objectContaining({ status: "succeeded", insertedCount: 1 }),
+			})
+		);
+	});
+
+	it("global lock을 얻지 못하면 실행하지 않고 409와 activeRunId를 반환한다", async () => {
+		const { client } = createSupabaseMock({ lockAcquired: false });
+		const runCrawler = vi.fn();
+
+		const error = await executeCrawlPipeline("arcalive", client, runCrawler).catch(
+			(result: unknown) => result
+		);
+
+		expect(error).toBeInstanceOf(CrawlPipelineError);
+		expect(error).toMatchObject({ httpStatus: 409, activeRunId: "41" });
+		expect(runCrawler).not.toHaveBeenCalled();
+	});
+
+	it("모든 소스가 timeout이면 실패 이력을 종료하고 504를 반환한다", async () => {
+		const { client, rpc } = createSupabaseMock();
+		const runCrawler = vi.fn().mockResolvedValue(
+			createExecutionResult({
+				items: [],
+				succeeded: 0,
+				failures: [
+					{
+						url: "https://example.com",
+						message: "timeout",
+						kind: "network",
+						timeout: true,
+						attempt: 1,
+					},
+				],
+			})
+		);
+
+		const error = await executeCrawlPipeline("arcalive", client, runCrawler).catch(
+			(result: unknown) => result
+		);
+
+		expect(error).toMatchObject({ httpStatus: 504, stage: "source", runId: "42" });
+		expect(rpc).toHaveBeenCalledWith(
+			"finish_crawl_run",
+			expect.objectContaining({
+				p_result: expect.objectContaining({ status: "failed", timeoutFailureCount: 1 }),
+			})
+		);
+		expect(rpc).not.toHaveBeenCalledWith("release_crawl_lock", expect.anything());
+	});
+
+	it("실행 이력 종료가 실패하면 lock fallback을 수행한다", async () => {
+		const { client, rpc } = createSupabaseMock({ finishError: true });
+
+		await expect(
+			executeCrawlPipeline("arcalive", client, vi.fn().mockResolvedValue(createExecutionResult()))
+		).rejects.toMatchObject({ httpStatus: 500, stage: "unknown", runId: "42" });
+		expect(rpc).toHaveBeenCalledWith(
+			"release_crawl_lock",
+			expect.objectContaining({ p_lock_key: "global-crawl" })
+		);
+	});
+});

--- a/app/api/crawl/pipeline.ts
+++ b/app/api/crawl/pipeline.ts
@@ -1,0 +1,302 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { CrawlItemType } from "@/lib/type-defs";
+import type { CrawlExecutionResult, CrawlTarget } from "./contracts";
+import { getErrorMessage } from "./contracts";
+import { runCrawlerWithRetry } from "./crawl-runner";
+import {
+	type CrawlErrorStage,
+	chunkUrlsForHistoryQuery,
+	createRunResult,
+	dedupeByUrl,
+	defineType,
+	type FilterKeyword,
+	getCompletedRunStatus,
+} from "./pipeline-helpers";
+
+const CRAWL_LOCK_KEY = "global-crawl";
+const CRAWL_LOCK_TTL_SECONDS = 300;
+
+interface CrawlRunHandle {
+	runId: string;
+	lockToken: string;
+}
+
+interface PreparedCrawlItem extends CrawlItemType {
+	type: string;
+}
+
+export interface ManualCrawlSuccess {
+	runId: string;
+	status: "succeeded" | "partial";
+	target: CrawlTarget;
+	insertedCount: number;
+	skippedCount: number;
+	warningCount: number;
+	durationMs: number;
+}
+
+export class CrawlPipelineError extends Error {
+	constructor(
+		message: string,
+		readonly httpStatus: number,
+		readonly stage: CrawlErrorStage,
+		readonly crawlData: CrawlExecutionResult | null = null,
+		readonly runId?: string,
+		readonly activeRunId?: string | null
+	) {
+		super(message);
+		this.name = "CrawlPipelineError";
+	}
+}
+
+type CrawlRunner = (target: CrawlTarget) => Promise<CrawlExecutionResult>;
+
+async function beginCrawlRun(
+	supabase: SupabaseClient,
+	target: CrawlTarget
+): Promise<CrawlRunHandle> {
+	const lockToken = crypto.randomUUID();
+	const { data, error } = await supabase.rpc("begin_crawl_run", {
+		p_source: target,
+		p_lock_token: lockToken,
+		p_ttl_seconds: CRAWL_LOCK_TTL_SECONDS,
+	});
+	if (error) {
+		throw new CrawlPipelineError(error.message, 500, "unknown");
+	}
+
+	const result = (data ?? {}) as {
+		acquired?: boolean;
+		runId?: string;
+		activeRunId?: string | null;
+	};
+	if (!result.acquired) {
+		throw new CrawlPipelineError(
+			"다른 크롤링 작업이 이미 실행 중입니다.",
+			409,
+			"unknown",
+			null,
+			undefined,
+			result.activeRunId ?? null
+		);
+	}
+	if (typeof result.runId !== "string") {
+		throw new CrawlPipelineError("Crawl run could not be created.", 500, "unknown");
+	}
+
+	return { runId: result.runId, lockToken };
+}
+
+async function loadFilterKeywords(supabase: SupabaseClient) {
+	const { data, error } = await supabase.from("filter-keyword").select("value, method");
+	if (error) {
+		throw new CrawlPipelineError(error.message, 500, "filter");
+	}
+	return (data ?? []) as FilterKeyword[];
+}
+
+async function getExistingUrls(supabase: SupabaseClient, target: CrawlTarget, urls: string[]) {
+	const existingUrls = new Set<string>();
+	for (const chunk of chunkUrlsForHistoryQuery(urls)) {
+		const { data, error } = await supabase
+			.from("crawl-history")
+			.select("url")
+			.eq("crawl_source", target)
+			.in("url", chunk);
+		if (error) {
+			throw new CrawlPipelineError(error.message, 500, "history");
+		}
+		for (const row of (data ?? []) as { url: string | null }[]) {
+			if (typeof row.url === "string") {
+				existingUrls.add(row.url);
+			}
+		}
+	}
+	return existingUrls;
+}
+
+async function prepareItems(
+	supabase: SupabaseClient,
+	target: CrawlTarget,
+	crawlData: CrawlExecutionResult,
+	filterList: FilterKeyword[]
+) {
+	const ignoreList = filterList
+		.filter((keyword) => keyword.method === "ignore")
+		.map((keyword) => keyword.value);
+	const filteredItems = dedupeByUrl(
+		crawlData.items.filter(
+			(item) => item.url && !ignoreList.some((keyword) => item.url.includes(keyword))
+		)
+	);
+	const existingUrls = await getExistingUrls(
+		supabase,
+		target,
+		filteredItems.map((item) => item.url)
+	);
+	const items: PreparedCrawlItem[] = filteredItems
+		.filter((item) => !existingUrls.has(item.url))
+		.map((item) => ({ ...item, type: defineType(item.url, filterList) }));
+	return { items, existingCount: existingUrls.size };
+}
+
+async function ingestItems(
+	supabase: SupabaseClient,
+	target: CrawlTarget,
+	items: PreparedCrawlItem[]
+) {
+	const { data, error } = await supabase.rpc("ingest_crawl_items", {
+		p_crawl_source: target,
+		p_items: items,
+	});
+	if (error) {
+		throw new CrawlPipelineError(error.message, 500, "ingest");
+	}
+	return (data ?? {}) as { insertedCount?: number; skippedCount?: number };
+}
+
+async function finishCrawlRun(
+	supabase: SupabaseClient,
+	handle: CrawlRunHandle,
+	result: ReturnType<typeof createRunResult>
+) {
+	const { data, error } = await supabase.rpc("finish_crawl_run", {
+		p_run_id: handle.runId,
+		p_lock_token: handle.lockToken,
+		p_result: result,
+	});
+	if (error) {
+		throw new CrawlPipelineError(error.message, 500, "unknown");
+	}
+	return (data ?? {}) as { durationMs?: number };
+}
+
+async function releaseCrawlLockFallback(supabase: SupabaseClient, lockToken: string) {
+	const { error } = await supabase.rpc("release_crawl_lock", {
+		p_lock_key: CRAWL_LOCK_KEY,
+		p_lock_token: lockToken,
+	});
+	if (error) {
+		console.error("[crawl] lock_release_failed", { message: error.message });
+	}
+}
+
+function normalizePipelineError(error: unknown, crawlData: CrawlExecutionResult | null) {
+	if (error instanceof CrawlPipelineError) {
+		return new CrawlPipelineError(
+			error.message,
+			error.httpStatus,
+			error.stage,
+			error.crawlData ?? crawlData
+		);
+	}
+	return new CrawlPipelineError(getErrorMessage(error), 500, "source", crawlData);
+}
+
+function assertSuccessfulSourceResult(crawlData: CrawlExecutionResult) {
+	if (crawlData.succeeded > 0) {
+		return;
+	}
+	const allFailuresTimedOut =
+		crawlData.failures.length > 0 &&
+		crawlData.failures.every((failure) => failure.timeout === true);
+	throw new CrawlPipelineError(
+		"모든 소스 요청이 실패했습니다.",
+		allFailuresTimedOut ? 504 : 502,
+		"source",
+		crawlData
+	);
+}
+
+export async function executeCrawlPipeline(
+	target: CrawlTarget,
+	supabase: SupabaseClient,
+	runCrawler: CrawlRunner = runCrawlerWithRetry
+): Promise<ManualCrawlSuccess> {
+	const handle = await beginCrawlRun(supabase, target);
+	let crawlData: CrawlExecutionResult | null = null;
+	let finalized = false;
+	console.info("[crawl] run_started", { runId: handle.runId, target });
+
+	try {
+		try {
+			crawlData = await runCrawler(target);
+			assertSuccessfulSourceResult(crawlData);
+		} catch (error) {
+			throw normalizePipelineError(error, crawlData);
+		}
+
+		const filterList = await loadFilterKeywords(supabase);
+		const prepared = await prepareItems(supabase, target, crawlData, filterList);
+		const counts = await ingestItems(supabase, target, prepared.items);
+		const insertedCount = Number(counts.insertedCount ?? 0);
+		const skippedCount = prepared.existingCount + Number(counts.skippedCount ?? 0);
+		const status = getCompletedRunStatus(crawlData);
+		const completion = await finishCrawlRun(
+			supabase,
+			handle,
+			createRunResult(status, crawlData, insertedCount, skippedCount)
+		);
+		finalized = true;
+		const durationMs = Number(completion.durationMs ?? 0);
+		console.info("[crawl] run_completed", {
+			runId: handle.runId,
+			target,
+			status,
+			insertedCount,
+			skippedCount,
+			durationMs,
+		});
+
+		return {
+			runId: handle.runId,
+			status,
+			target,
+			insertedCount,
+			skippedCount,
+			warningCount: crawlData.failures.length + crawlData.warnings.length,
+			durationMs,
+		};
+	} catch (error) {
+		const pipelineError = normalizePipelineError(error, crawlData);
+		try {
+			await finishCrawlRun(
+				supabase,
+				handle,
+				createRunResult(
+					"failed",
+					pipelineError.crawlData,
+					0,
+					0,
+					pipelineError.stage,
+					pipelineError.message
+				)
+			);
+			finalized = true;
+		} catch (finishError) {
+			console.error("[crawl] run_finalization_failed", {
+				runId: handle.runId,
+				target,
+				message: getErrorMessage(finishError),
+			});
+		}
+
+		console.error("[crawl] run_failed", {
+			runId: handle.runId,
+			target,
+			stage: pipelineError.stage,
+			message: pipelineError.message,
+		});
+		throw new CrawlPipelineError(
+			pipelineError.message,
+			pipelineError.httpStatus,
+			pipelineError.stage,
+			pipelineError.crawlData,
+			handle.runId
+		);
+	} finally {
+		if (!finalized) {
+			await releaseCrawlLockFallback(supabase, handle.lockToken);
+		}
+	}
+}

--- a/app/api/crawl/route.ts
+++ b/app/api/crawl/route.ts
@@ -1,45 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { crawlArcalive } from "./arcalive";
-import { crawlBattlepage } from "./battlepage";
-import {
-	aggregateCrawlAttempts,
-	type CrawlExecutionResult,
-	type CrawlSourceResult,
-	type CrawlTarget,
-	getErrorMessage,
-	isCrawlTarget,
-} from "./contracts";
-import { crawlInsagirl } from "./insagirl";
+import { type CrawlExecutionResult, getErrorMessage, isCrawlTarget } from "./contracts";
+import { runCrawlerWithRetry } from "./crawl-runner";
 import { hasMinimumInternalSecretLength, hasValidInternalSecret } from "./internal-auth";
-import { crawlIssuelink } from "./issuelink";
-import { debugLog, infoLog } from "./logger";
-
-const CRAWLERS: Record<CrawlTarget, () => Promise<CrawlSourceResult>> = {
-	arcalive: crawlArcalive,
-	battlepage: crawlBattlepage,
-	insagirl: crawlInsagirl,
-	issuelink: crawlIssuelink,
-};
-
-async function runCrawlerWithRetry(target: CrawlTarget) {
-	const attempts: CrawlSourceResult[] = [];
-
-	for (let attempt = 1; attempt <= 2; attempt += 1) {
-		const result = await CRAWLERS[target]();
-		attempts.push(result);
-		if (result.succeeded > 0) {
-			return aggregateCrawlAttempts(attempts);
-		}
-
-		if (attempt < 2) {
-			const delay = 1000 * 2 ** (attempt - 1);
-			debugLog(`[Crawl API] ${target} 전체 요청 실패, ${delay}ms 후 재시도`);
-			await new Promise((resolve) => setTimeout(resolve, delay));
-		}
-	}
-
-	return aggregateCrawlAttempts(attempts);
-}
+import { infoLog } from "./logger";
 
 function emptyExecutionResult(): CrawlExecutionResult {
 	return {

--- a/docs/P0_DEPLOYMENT.md
+++ b/docs/P0_DEPLOYMENT.md
@@ -16,10 +16,14 @@ pnpm build
 Next 런타임에는 다음 값을 설정합니다.
 
 - `CRAWL_INTERNAL_SECRET`: 임의 생성한 32바이트 이상의 값
+- `CRAWL_EXECUTION_MODE`: 첫 호환 배포는 `edge`, 검증 후 `next`
 - `SUPABASE_SERVICE_ROLE_KEY`: 서버 전용 키
 - `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 
 Edge Function에는 같은 `CRAWL_INTERNAL_SECRET`과 `CRAWL_API_BASE_URL`을 설정합니다. secret 값은 명령 기록이나 문서에 남기지 않습니다.
+
+`CRAWL_INTERNAL_SECRET`과 `CRAWL_API_BASE_URL`은 Next 직접 실행 전환 후 1주간 rollback을 위해
+유지합니다. 관찰 기간이 끝나기 전에는 Edge Function 또는 내부 `/api/crawl`을 제거하지 않습니다.
 
 ## 2. 원격 baseline과 migration history 정렬
 
@@ -48,7 +52,10 @@ supabase functions deploy crawl-source
 supabase db push
 ```
 
-Edge를 먼저 배포해 신규 Media·YouTube 적재를 중단한 다음 DB migration과 Next를 연속 적용합니다. 통계 RPC 시그니처가 변경되므로 DB와 Next 사이의 간격을 최소화합니다. `supabase/config.toml`의 `verify_jwt = true`와 Auth signup 비활성화 설정을 유지합니다.
+DB와 기존 Edge를 먼저 배포한 다음 `CRAWL_EXECUTION_MODE=edge`인 호환 Next 빌드를 배포합니다.
+호환 경로가 정상인지 확인한 뒤 Vercel 환경 변수를 `next`로 변경하고 다시 배포합니다. 통계 RPC
+시그니처가 변경되는 배포에서는 DB와 Next 사이의 간격을 최소화합니다. 전환 기간에는
+`supabase/config.toml`의 `verify_jwt = true`와 Auth signup 비활성화 설정을 유지합니다.
 
 새 배포가 정상임을 확인한 뒤 Edge Function의 기존 `NEXT_PUBLIC_IMGUR_CLIENT_ID`, `MEDIA_FETCH_CONCURRENCY` secret과 Vercel의 `CRAWL_ALLOWED_USER_IDS`, 미사용 `DATABASE_PASSWORD` 환경 변수를 삭제합니다.
 
@@ -63,4 +70,23 @@ Edge를 먼저 배포해 신규 Media·YouTube 적재를 중단한 다음 DB mig
 7. 개인 계정으로 Main, Quick Save, Trash를 조회하고 Main→Quick Save→Trash→Restore 및 모두 휴지통으로 이동을 확인합니다.
 8. `media`, `youtube` 타입 행과 분류 키워드가 0건이고 세 스레드 테이블에 `sub_url` 컬럼이 없는지 확인합니다.
 
-문제가 발생하면 Next와 Edge를 함께 이전 버전으로 되돌립니다. 삭제된 행과 `sub_url` 값은 migration만으로 복구할 수 없으므로 배포 전 백업이 필요합니다.
+Next 직접 실행에서 문제가 발생하면 `CRAWL_EXECUTION_MODE=edge`로 되돌린 호환 빌드를
+재배포합니다. 크롤링 DB RPC와 스키마는 양쪽 경로가 공유하므로 이 전환만으로는 DB rollback을
+수행하지 않습니다. 삭제된 행과 `sub_url` 값은 migration만으로 복구할 수 없으므로 배포 전
+백업이 필요합니다.
+
+## 5. Next 직접 실행 전환 완료
+
+`CRAWL_EXECUTION_MODE=next`로 1주간 운영하면서 다음 항목을 확인합니다.
+
+1. 네 소스를 각각 두 번 이상 실행하고 적재·중복 제외 결과를 확인합니다.
+2. 동시 실행의 `409`, timeout의 `504`, 일반 소스 실패의 `502` 응답을 확인합니다.
+3. 실행 이력 dashboard, parser 추세, crawler-health 알림이 정상 집계되는지 확인합니다.
+4. 실패한 실행 뒤 `crawl_run_locks`에 global lock이 남지 않는지 확인합니다.
+
+관찰 기간이 정상적으로 끝난 다음 별도 정리 배포에서 Supabase Edge Function `crawl-source`, 내부
+`POST /api/crawl`, Edge/Deno 전용 helper와 테스트를 제거합니다. 이어서 Vercel과 Supabase에서
+`CRAWL_INTERNAL_SECRET`, Edge의 `CRAWL_API_BASE_URL`을 제거하고 CI의 Edge 검사 명령도 정리합니다.
+
+정리 이후 긴급 rollback이 필요하면 secret manager의 기존 값을 복원하고 이전 호환 Next 빌드와
+Edge Function을 함께 재배포합니다.

--- a/utils/supabase/service-role.ts
+++ b/utils/supabase/service-role.ts
@@ -1,0 +1,26 @@
+import { createClient } from "@supabase/supabase-js";
+
+function requireServerEnv(value: string | undefined, key: string) {
+	if (!value) {
+		throw new Error(`${key} is not defined. Check your server environment configuration.`);
+	}
+	return value;
+}
+
+export function createServiceRoleClient() {
+	const supabaseUrl = requireServerEnv(
+		process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL,
+		"SUPABASE_URL"
+	);
+	const serviceRoleKey = requireServerEnv(
+		process.env.SUPABASE_SERVICE_ROLE_KEY,
+		"SUPABASE_SERVICE_ROLE_KEY"
+	);
+
+	return createClient(supabaseUrl, serviceRoleKey, {
+		auth: {
+			autoRefreshToken: false,
+			persistSession: false,
+		},
+	});
+}


### PR DESCRIPTION
## 요약
- `CRAWL_EXECUTION_MODE=next`에서 수동 크롤링이 Supabase Edge Function을 거치지 않고 Next API 내부 파이프라인으로 직접 실행되도록 추가했습니다.
- 크롤러 재시도 로직을 `crawl-runner`로 분리해 기존 내부 `/api/crawl`과 새 파이프라인이 공유하도록 정리했습니다.
- global DB lock 생성, 필터/중복 제거, `ingest_crawl_items`, `finish_crawl_run`, lock fallback 해제를 포함한 Next 기반 크롤링 파이프라인을 추가했습니다.
- service-role Supabase 클라이언트 유틸을 추가하고, `edge` 모드 fallback과 오류 응답 계약을 유지했습니다.
- README와 P0 배포 문서에 `edge`에서 `next`로 전환하는 운영 절차와 rollback 유지 기간을 반영했습니다.

## 테스트
- `app/api/crawl/manual/route.test.ts`에 Next 실행 모드, lock 충돌, timeout, 설정 오류, 예상 외 오류 케이스를 추가했습니다.
- `app/api/crawl/pipeline-helpers.test.ts`에 URL 중복 제거, 타입 분류, history 조회 chunking, 실행 결과 집계 테스트를 추가했습니다.
- `app/api/crawl/pipeline.test.ts`에 정상 실행, lock 충돌, timeout 실패 종료, lock fallback 테스트를 추가했습니다.