### PR TITLE
내부 예약 API 인증 헤더 보존

### DIFF
--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -14,8 +14,12 @@ describe("proxy", () => {
 		updateSessionMock.mockResolvedValue(NextResponse.next());
 	});
 
-	it("내부 크롤링 API는 세션 proxy를 우회해 원본 요청 헤더를 보존한다", async () => {
-		const request = new NextRequest("http://localhost/api/crawl", {
+	it.each([
+		"/api/crawl",
+		"/api/crawl/alerts/notifications",
+		"/api/crawl/scheduled",
+	])("내부 크롤링 API %s는 세션 proxy를 우회해 원본 요청 헤더를 보존한다", async (pathname) => {
+		const request = new NextRequest(`http://localhost${pathname}`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,9 +1,15 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { updateSession } from "@/utils/supabase/middleware";
 
+const INTERNAL_CRAWL_API_PATHS = new Set([
+	"/api/crawl",
+	"/api/crawl/alerts/notifications",
+	"/api/crawl/scheduled",
+]);
+
 export async function proxy(request: NextRequest) {
 	// 내부 크롤링 API는 쿠키 세션을 사용하지 않으며 원본 인증 헤더와 JSON body를 보존해야 한다.
-	if (request.nextUrl.pathname === "/api/crawl") {
+	if (INTERNAL_CRAWL_API_PATHS.has(request.nextUrl.pathname)) {
 		return NextResponse.next();
 	}
 


### PR DESCRIPTION
## 변경 사항
- 예약 크롤링과 알림 내부 API가 세션 proxy를 우회하도록 수정
- 내부 인증 헤더가 Route Handler까지 보존되는 회귀 테스트 추가

## 검증
- pnpm exec vitest run proxy.test.ts app/api/crawl/scheduled/route.test.ts app/api/crawl/alerts/notifications/route.test.ts
- pnpm exec biome check proxy.ts proxy.test.ts --error-on-warnings