### PR TITLE
예약 인증 실패 시 스케줄러 안전 중단

### DIFF
--- a/app/api/crawl/scheduled/route.test.ts
+++ b/app/api/crawl/scheduled/route.test.ts
@@ -57,7 +57,9 @@ describe("POST /api/crawl/scheduled", () => {
 	});
 
 	it("내부 secret과 활성 target을 검증한다", async () => {
-		expect((await POST(request("arcalive", "wrong"))).status).toBe(401);
+		const unauthorized = await POST(request("arcalive", "wrong"));
+		expect(unauthorized.status).toBe(401);
+		expect(await unauthorized.json()).toMatchObject({ reason: "invalid-secret" });
 		expect((await POST(request("issuelink"))).status).toBe(400);
 	});
 
@@ -91,6 +93,7 @@ describe("POST /api/crawl/scheduled", () => {
 		const response = await POST(request("arcalive"));
 
 		expect(response.status).toBe(503);
+		expect(await response.json()).toMatchObject({ reason: "configuration-invalid" });
 		expect(executeCrawlPipelineMock).not.toHaveBeenCalled();
 	});
 

--- a/app/api/crawl/scheduled/route.ts
+++ b/app/api/crawl/scheduled/route.ts
@@ -101,12 +101,18 @@ export async function POST(request: NextRequest) {
 	const expectedSecret = process.env.CRAWL_INTERNAL_SECRET;
 	if (!hasMinimumInternalSecretLength(expectedSecret)) {
 		return NextResponse.json(
-			{ error: "예약 크롤링 인증 설정이 완료되지 않았습니다." },
+			{
+				error: "예약 크롤링 인증 설정이 완료되지 않았습니다.",
+				reason: "configuration-missing",
+			},
 			{ status: 503 }
 		);
 	}
 	if (!hasValidInternalSecret(request.headers.get("x-applemint-internal-secret"), expectedSecret)) {
-		return NextResponse.json({ error: "인증되지 않은 예약 크롤링 요청입니다." }, { status: 401 });
+		return NextResponse.json(
+			{ error: "인증되지 않은 예약 크롤링 요청입니다.", reason: "invalid-secret" },
+			{ status: 401 }
+		);
 	}
 
 	const body = (await request.json().catch(() => null)) as { target?: unknown } | null;
@@ -119,7 +125,10 @@ export async function POST(request: NextRequest) {
 			configuredMode: process.env.CRAWL_EXECUTION_MODE,
 		});
 		return NextResponse.json(
-			{ error: "크롤링 실행 모드 설정이 올바르지 않습니다." },
+			{
+				error: "크롤링 실행 모드 설정이 올바르지 않습니다.",
+				reason: "configuration-invalid",
+			},
 			{ status: 503 }
 		);
 	}

--- a/docs/CRAWL_SCHEDULING.md
+++ b/docs/CRAWL_SCHEDULING.md
@@ -34,9 +34,10 @@ attempt를 가진 작업 큐가 아닙니다. URL과 secret은 migration에 넣�
 Vault 값이 없거나 올바르지 않으면 dispatcher는 `configuration-missing`으로 종료하고 외부 요청을
 보내지 않습니다. Next 운영 환경의 `CRAWL_EXECUTION_MODE`는 `next`로 설정합니다.
 
-예약 API가 `401` 또는 `403`을 반환하면 reconciler는 secret 또는 접근 정책 불일치로 판단해
-`scheduler_enabled=false`로 예약을 자동 중지합니다. 수동 수집은 계속 사용할 수 있습니다. Vault와
-Vercel의 `CRAWL_INTERNAL_SECRET`을 동일하게 맞춘 뒤 스모크 테스트를 통과해야 다시 활성화합니다.
+예약 API가 `401`, `403`을 반환하거나 `configuration-missing`, `configuration-invalid` 사유를
+반환하면 reconciler는 secret 또는 접근 정책 불일치로 판단해 `scheduler_enabled=false`로 예약을
+자동 중지합니다. 수동 수집은 계속 사용할 수 있습니다. Vault와 Vercel의
+`CRAWL_INTERNAL_SECRET`을 동일하게 맞춘 뒤 스모크 테스트를 통과해야 다시 활성화합니다.
 `404`는 배포 전환 중 일시적으로 발생할 수 있으므로 감사 로그에 `endpoint-not-found`로 기록하되
 예약을 자동 중지하지 않습니다.
 

--- a/docs/CRAWL_SCHEDULING.md
+++ b/docs/CRAWL_SCHEDULING.md
@@ -34,6 +34,12 @@ attempt를 가진 작업 큐가 아닙니다. URL과 secret은 migration에 넣�
 Vault 값이 없거나 올바르지 않으면 dispatcher는 `configuration-missing`으로 종료하고 외부 요청을
 보내지 않습니다. Next 운영 환경의 `CRAWL_EXECUTION_MODE`는 `next`로 설정합니다.
 
+예약 API가 `401` 또는 `403`을 반환하면 reconciler는 secret 또는 접근 정책 불일치로 판단해
+`scheduler_enabled=false`로 예약을 자동 중지합니다. 수동 수집은 계속 사용할 수 있습니다. Vault와
+Vercel의 `CRAWL_INTERNAL_SECRET`을 동일하게 맞춘 뒤 스모크 테스트를 통과해야 다시 활성화합니다.
+`404`는 배포 전환 중 일시적으로 발생할 수 있으므로 감사 로그에 `endpoint-not-found`로 기록하되
+예약을 자동 중지하지 않습니다.
+
 ## GitHub Actions 전환과 복구
 
 전환 기간에는 `.github/workflows/crawler-schedule.yml`의 cron을 남겨두되 repository variable

--- a/supabase/migrations/20260722160000_crawl_scheduler_auth_fail_closed.sql
+++ b/supabase/migrations/20260722160000_crawl_scheduler_auth_fail_closed.sql
@@ -1,0 +1,86 @@
+-- 예약 endpoint 인증이 깨진 상태에서는 5분마다 같은 실패를 반복하지 않는다.
+-- 응답 사유를 감사 로그에 정규화하고 401/403이면 예약만 자동 중지한다.
+create or replace function public.reconcile_crawl_schedule_dispatches()
+returns bigint
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+	v_dispatch record;
+	v_response record;
+	v_body jsonb;
+	v_state text;
+	v_reason text;
+	v_run_id bigint;
+	v_resolved_count bigint := 0;
+begin
+	for v_dispatch in
+		select * from public.crawl_schedule_dispatches
+		where state = 'queued'
+		order by created_at, id
+	loop
+		select response.* into v_response
+		from net._http_response as response
+		where response.id = v_dispatch.request_id;
+
+		if found then
+			begin
+				v_body := coalesce(v_response.content, '{}')::jsonb;
+			exception when others then
+				v_body := jsonb_build_object('raw', v_response.content);
+			end;
+
+			v_reason := coalesce(
+				nullif(v_body ->> 'reason', ''),
+				case v_response.status_code
+					when 401 then 'authentication'
+					when 403 then 'authorization'
+					when 404 then 'endpoint-not-found'
+					else null
+				end
+			);
+			v_run_id := case
+				when coalesce(v_body ->> 'runId', '') ~ '^[0-9]+$' then (v_body ->> 'runId')::bigint
+				else null
+			end;
+			if v_run_id is not null and not exists (
+				select 1 from public.crawl_runs where id = v_run_id
+			) then
+				v_run_id := null;
+			end if;
+			v_state := case
+				when coalesce(v_response.timed_out, false) or v_response.error_msg is not null then 'transport-error'
+				when v_body ->> 'status' = 'skipped' or v_reason = 'capacity' then 'skipped'
+				when v_response.status_code between 200 and 299 then 'succeeded'
+				else 'failed'
+			end;
+
+			update public.crawl_schedule_dispatches
+			set
+				state = v_state,
+				http_status = v_response.status_code,
+				admission_reason = v_reason,
+				run_id = v_run_id,
+				response_body = v_body,
+				resolved_at = now()
+			where id = v_dispatch.id;
+
+			if v_response.status_code in (401, 403) then
+				update public.crawl_runtime_settings
+				set scheduler_enabled = false
+				where id = true and scheduler_enabled;
+			end if;
+
+			v_resolved_count := v_resolved_count + 1;
+		elsif v_dispatch.created_at <= now() - interval '2 minutes' then
+			update public.crawl_schedule_dispatches
+			set state = 'expired', resolved_at = now()
+			where id = v_dispatch.id;
+			v_resolved_count := v_resolved_count + 1;
+		end if;
+	end loop;
+
+	return v_resolved_count;
+end;
+$$;

--- a/supabase/migrations/20260722170000_crawl_scheduler_configuration_fail_closed.sql
+++ b/supabase/migrations/20260722170000_crawl_scheduler_configuration_fail_closed.sql
@@ -1,0 +1,87 @@
+-- 인증 설정 자체가 누락되거나 잘못된 경우에도 실패 요청을 5분마다 반복하지 않는다.
+create or replace function public.reconcile_crawl_schedule_dispatches()
+returns bigint
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+	v_dispatch record;
+	v_response record;
+	v_body jsonb;
+	v_state text;
+	v_reason text;
+	v_run_id bigint;
+	v_resolved_count bigint := 0;
+begin
+	for v_dispatch in
+		select * from public.crawl_schedule_dispatches
+		where state = 'queued'
+		order by created_at, id
+	loop
+		select response.* into v_response
+		from net._http_response as response
+		where response.id = v_dispatch.request_id;
+
+		if found then
+			begin
+				v_body := coalesce(v_response.content, '{}')::jsonb;
+			exception when others then
+				v_body := jsonb_build_object('raw', v_response.content);
+			end;
+
+			v_reason := coalesce(
+				nullif(v_body ->> 'reason', ''),
+				case v_response.status_code
+					when 401 then 'authentication'
+					when 403 then 'authorization'
+					when 404 then 'endpoint-not-found'
+					else null
+				end
+			);
+			v_run_id := case
+				when coalesce(v_body ->> 'runId', '') ~ '^[0-9]+$' then (v_body ->> 'runId')::bigint
+				else null
+			end;
+			if v_run_id is not null and not exists (
+				select 1 from public.crawl_runs where id = v_run_id
+			) then
+				v_run_id := null;
+			end if;
+			v_state := case
+				when coalesce(v_response.timed_out, false) or v_response.error_msg is not null then 'transport-error'
+				when v_body ->> 'status' = 'skipped' or v_reason = 'capacity' then 'skipped'
+				when v_response.status_code between 200 and 299 then 'succeeded'
+				else 'failed'
+			end;
+
+			update public.crawl_schedule_dispatches
+			set
+				state = v_state,
+				http_status = v_response.status_code,
+				admission_reason = v_reason,
+				run_id = v_run_id,
+				response_body = v_body,
+				resolved_at = now()
+			where id = v_dispatch.id;
+
+			if v_response.status_code in (401, 403)
+				or v_reason in ('configuration-missing', 'configuration-invalid')
+			then
+				update public.crawl_runtime_settings
+				set scheduler_enabled = false
+				where id = true and scheduler_enabled;
+			end if;
+
+			v_resolved_count := v_resolved_count + 1;
+		elsif v_dispatch.created_at <= now() - interval '2 minutes' then
+			update public.crawl_schedule_dispatches
+			set state = 'expired', resolved_at = now()
+			where id = v_dispatch.id;
+			v_resolved_count := v_resolved_count + 1;
+		end if;
+	end loop;
+
+	return v_resolved_count;
+end;
+$$;

--- a/supabase/tests/p8_crawl_scheduler_auth_fail_closed.test.sql
+++ b/supabase/tests/p8_crawl_scheduler_auth_fail_closed.test.sql
@@ -1,6 +1,6 @@
 begin;
 
-select plan(5);
+select plan(8);
 
 update public.crawl_runtime_settings set scheduler_enabled = true where id = true;
 
@@ -49,6 +49,45 @@ select is(
 	(select response_body ->> 'error' from public.crawl_schedule_dispatches where request_id = 8800001),
 	'unauthorized',
 	'safe response details remain available in the dispatch audit'
+);
+
+update public.crawl_runtime_settings set scheduler_enabled = true where id = true;
+
+insert into public.crawl_schedule_dispatches (
+	scheduled_for, source, request_id, state
+)
+values ('2026-07-22 16:05:00+00', 'battlepage', 8800002, 'queued');
+
+insert into net._http_response (
+	id, status_code, content_type, headers, content, timed_out, error_msg
+)
+values (
+	8800002,
+	503,
+	'application/json',
+	'{}'::jsonb,
+	'{"error":"configuration missing","reason":"configuration-missing"}',
+	false,
+	null
+);
+
+set local role service_role;
+select is(
+	public.reconcile_crawl_schedule_dispatches(),
+	1::bigint,
+	'reconciler settles an authentication configuration failure'
+);
+reset role;
+
+select is(
+	(select admission_reason from public.crawl_schedule_dispatches where request_id = 8800002),
+	'configuration-missing',
+	'authentication configuration reason is preserved for operations'
+);
+select is(
+	(select scheduler_enabled from public.crawl_runtime_settings where id = true),
+	false,
+	'authentication configuration failure disables scheduled dispatches'
 );
 
 select * from finish();

--- a/supabase/tests/p8_crawl_scheduler_auth_fail_closed.test.sql
+++ b/supabase/tests/p8_crawl_scheduler_auth_fail_closed.test.sql
@@ -1,0 +1,56 @@
+begin;
+
+select plan(5);
+
+update public.crawl_runtime_settings set scheduler_enabled = true where id = true;
+
+insert into public.crawl_schedule_dispatches (
+	scheduled_for, source, request_id, state
+)
+values ('2026-07-22 16:00:00+00', 'arcalive', 8800001, 'queued');
+
+insert into net._http_response (
+	id, status_code, content_type, headers, content, timed_out, error_msg
+)
+values (
+	8800001,
+	401,
+	'application/json',
+	'{}'::jsonb,
+	'{"error":"unauthorized","reason":"invalid-secret"}',
+	false,
+	null
+);
+
+set local role service_role;
+select is(
+	public.reconcile_crawl_schedule_dispatches(),
+	1::bigint,
+	'reconciler settles an authentication failure'
+);
+reset role;
+
+select is(
+	(select state from public.crawl_schedule_dispatches where request_id = 8800001),
+	'failed',
+	'authentication response is recorded as failed'
+);
+select is(
+	(select admission_reason from public.crawl_schedule_dispatches where request_id = 8800001),
+	'invalid-secret',
+	'endpoint authentication reason is preserved for operations'
+);
+select is(
+	(select scheduler_enabled from public.crawl_runtime_settings where id = true),
+	false,
+	'authentication failure disables scheduled dispatches'
+);
+select is(
+	(select response_body ->> 'error' from public.crawl_schedule_dispatches where request_id = 8800001),
+	'unauthorized',
+	'safe response details remain available in the dispatch audit'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## 변경 사항
- 예약 API 인증·설정 오류에 명시적인 reason 추가
- 401/403 dispatch 정산 시 예약 스케줄러 자동 중단
- 404 endpoint 오류 정규화 및 운영 문서 보강
- 원격 DB에 적용된 migration과 pgTAP 회귀 테스트 저장소 반영

## 검증
- pnpm run ci
- 운영 pg_net 인증 스모크: HTTP 200 / skipped(cooldown)
- 첫 Supabase Cron dispatcher/reconciler succeeded